### PR TITLE
Fix /lib64 symlink target: point to usr/lib64 instead of usr/lib

### DIFF
--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -528,7 +528,7 @@ fn discover_base(hosts_file: &Path) -> Vec<Mount> {
             dest: "/lib".into(),
         },
         Mount::Symlink {
-            src: "usr/lib".into(),
+            src: "usr/lib64".into(),
             dest: "/lib64".into(),
         },
         Mount::RoBind {


### PR DESCRIPTION
## Summary
- Fix `/lib64` symlink target from `usr/lib` to `usr/lib64` in bwrap command builder
- On merged-usr systems (e.g. Ubuntu 24.04), the dynamic linker lives at `/usr/lib64/ld-linux-x86-64.so.2`, not `/usr/lib/`
- The wrong symlink caused `bwrap: execvp bash: No such file or directory` on every run

## Test plan
- [x] `cargo test` — all 102 tests pass
- [x] `ai-jail --dry-run bash | grep lib64` shows `--symlink usr/lib64 /lib64`
- [x] `ai-jail bash -c "echo ok"` runs successfully on Ubuntu 24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)