### PR TITLE
Fix macOS sandbox blocking Claude Code authentication

### DIFF
--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -284,7 +284,6 @@ fn macos_read_deny_paths() -> Vec<PathBuf> {
         .collect();
 
     candidates.extend([
-        home.join("Library/Keychains"),
         home.join("Library/Mail"),
         home.join("Library/Messages"),
         home.join("Library/Safari"),


### PR DESCRIPTION
## Summary

- Remove `~/Library/Keychains` from the seatbelt read-deny list
- On macOS, Claude Code stores OAuth tokens in the system Keychain. The sandbox was explicitly denying read access to `~/Library/Keychains`, causing Claude to lose its session and prompt for re-authentication on every launch.
- The macOS Keychain is already protected at the daemon level by `securityd` (per-item ACLs), so file-level read denial is redundant and breaks legitimate credential access.

## Test plan

- [x] `cargo test` — all 145 tests pass
- [x] Run `ai-jail claude` on macOS and verify Claude starts without requesting login