### PR TITLE
feat: allow TCP port allowlist in lockdown mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,7 @@ OPTIONS:
     -s, --status-bar[=light] Set status line theme (default on, dark unless =light)
     --no-status-bar          Disable persistent status line
     --exec                   Direct execution mode (no PTY proxy, no status bar)
+    --allow-tcp-port <PORT> Allow outbound TCP to PORT in lockdown (repeatable)
     --clean                 Ignore existing .ai-jail config, start fresh
     --dry-run               Print the sandbox command without executing
     --init                  Create/update .ai-jail config and exit
@@ -51,6 +52,7 @@ pub struct CliArgs {
     pub mise: Option<bool>,
     pub status_bar: Option<bool>,
     pub status_bar_style: Option<String>,
+    pub allow_tcp_ports: Vec<u16>,
     pub exec: bool,
     pub clean: bool,
     pub dry_run: bool,
@@ -92,6 +94,17 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
             Long("no-seccomp") => args.seccomp = Some(false),
             Long("rlimits") => args.rlimits = Some(true),
             Long("no-rlimits") => args.rlimits = Some(false),
+            Long("allow-tcp-port") => {
+                let val: String = parser
+                    .value()
+                    .map_err(|e| e.to_string())?
+                    .to_string_lossy()
+                    .into_owned();
+                let port: u16 = val
+                    .parse()
+                    .map_err(|_| format!("invalid port number: {val}"))?;
+                args.allow_tcp_ports.push(port);
+            }
             Long("gpu") => args.gpu = Some(true),
             Long("no-gpu") => args.gpu = Some(false),
             Long("docker") => args.docker = Some(true),
@@ -519,6 +532,56 @@ mod tests {
     fn parse_status_bar_eq_invalid() {
         let result = parse_test(&["--status-bar=neon", "bash"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_single() {
+        let args =
+            parse_test(&["--lockdown", "--allow-tcp-port", "32000", "bash"])
+                .unwrap();
+        assert_eq!(args.allow_tcp_ports, vec![32000]);
+        assert_eq!(args.lockdown, Some(true));
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_multiple() {
+        let args = parse_test(&[
+            "--allow-tcp-port",
+            "32000",
+            "--allow-tcp-port",
+            "8080",
+            "bash",
+        ])
+        .unwrap();
+        assert_eq!(args.allow_tcp_ports, vec![32000, 8080]);
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_boundary_values() {
+        let args = parse_test(&[
+            "--allow-tcp-port",
+            "0",
+            "--allow-tcp-port",
+            "65535",
+            "bash",
+        ])
+        .unwrap();
+        assert_eq!(args.allow_tcp_ports, vec![0, 65535]);
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_overflow() {
+        assert!(parse_test(&["--allow-tcp-port", "65536"]).is_err());
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_invalid() {
+        assert!(parse_test(&["--allow-tcp-port", "abc"]).is_err());
+    }
+
+    #[test]
+    fn parse_allow_tcp_port_missing_value() {
+        assert!(parse_test(&["--allow-tcp-port"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct Config {
     pub no_seccomp: Option<bool>,
     #[serde(default)]
     pub no_rlimits: Option<bool>,
+    #[serde(default)]
+    pub allow_tcp_ports: Vec<u16>,
 }
 
 impl Config {
@@ -70,6 +72,9 @@ impl Config {
     }
     pub fn rlimits_enabled(&self) -> bool {
         self.no_rlimits != Some(true)
+    }
+    pub fn allow_tcp_ports(&self) -> &[u16] {
+        &self.allow_tcp_ports
     }
 }
 
@@ -158,6 +163,9 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     if local.no_rlimits.is_some() {
         c.no_rlimits = local.no_rlimits;
     }
+    c.allow_tcp_ports.extend(local.allow_tcp_ports);
+    c.allow_tcp_ports.sort_unstable();
+    c.allow_tcp_ports.dedup();
     // Status bar stays from global — local should not override
     c
 }
@@ -325,6 +333,12 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     }
 
     config
+        .allow_tcp_ports
+        .extend(cli.allow_tcp_ports.iter().copied());
+    config.allow_tcp_ports.sort_unstable();
+    config.allow_tcp_ports.dedup();
+
+    config
 }
 
 pub fn display_status(config: &Config) {
@@ -379,6 +393,22 @@ pub fn display_status(config: &Config) {
     bool_opt("Seccomp", config.no_seccomp);
     bool_opt("Rlimits", config.no_rlimits);
     bool_opt("Lockdown", config.lockdown.map(|v| !v));
+    if !config.allow_tcp_ports.is_empty() {
+        let ports: Vec<String> = config
+            .allow_tcp_ports
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        let note = if config.lockdown_enabled() {
+            ""
+        } else {
+            " (only effective in lockdown mode)"
+        };
+        output::status_header(
+            "  Allow TCP ports",
+            &format!("{}{note}", ports.join(", ")),
+        );
+    }
     match config.no_status_bar {
         Some(true) => output::status_header("  Status bar", "disabled"),
         Some(false) => output::status_header("  Status bar", "enabled"),
@@ -524,6 +554,7 @@ another_removed_field = true
         assert_eq!(cfg.no_status_bar, None);
         assert_eq!(cfg.no_seccomp, None);
         assert_eq!(cfg.no_rlimits, None);
+        assert!(cfg.allow_tcp_ports.is_empty());
     }
 
     #[test]
@@ -583,6 +614,25 @@ no_status_bar = false
     }
 
     #[test]
+    fn regression_v0_6_0_config_without_allow_tcp_ports() {
+        let toml = r#"
+command = ["claude"]
+rw_maps = []
+ro_maps = []
+no_gpu = false
+no_docker = false
+lockdown = true
+no_landlock = false
+no_status_bar = false
+no_seccomp = false
+no_rlimits = false
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert!(cfg.allow_tcp_ports.is_empty());
+        assert_eq!(cfg.lockdown, Some(true));
+    }
+
+    #[test]
     fn regression_empty_config_file() {
         // An empty .ai-jail file must not crash
         let cfg = parse_toml("").unwrap();
@@ -614,6 +664,7 @@ no_status_bar = false
             status_bar_style: None,
             no_seccomp: None,
             no_rlimits: None,
+            allow_tcp_ports: vec![32000, 8080],
         };
         let serialized = serialize_config(&config).unwrap();
         let deserialized = parse_toml(&serialized).unwrap();
@@ -628,6 +679,7 @@ no_status_bar = false
         assert_eq!(deserialized.no_landlock, config.no_landlock);
         assert_eq!(deserialized.no_seccomp, config.no_seccomp);
         assert_eq!(deserialized.no_rlimits, config.no_rlimits);
+        assert_eq!(deserialized.allow_tcp_ports, config.allow_tcp_ports);
     }
 
     // ── Merge tests ────────────────────────────────────────────
@@ -781,6 +833,55 @@ no_status_bar = false
         };
         let merged = merge(&cli, existing);
         assert_eq!(merged.no_landlock, Some(true));
+    }
+
+    #[test]
+    fn merge_allow_tcp_ports_from_cli() {
+        let existing = Config {
+            allow_tcp_ports: vec![32000],
+            ..Config::default()
+        };
+        let cli = CliArgs {
+            allow_tcp_ports: vec![8080, 32000],
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(merged.allow_tcp_ports, vec![8080, 32000]);
+    }
+
+    #[test]
+    fn merge_allow_tcp_ports_with_global() {
+        let global = Config {
+            allow_tcp_ports: vec![443],
+            ..Config::default()
+        };
+        let local = Config {
+            allow_tcp_ports: vec![32000, 443],
+            ..Config::default()
+        };
+        let merged = merge_with_global(global, local);
+        assert_eq!(merged.allow_tcp_ports, vec![443, 32000]);
+    }
+
+    #[test]
+    fn allow_tcp_ports_accessor() {
+        let cfg = Config {
+            allow_tcp_ports: vec![32000, 8080],
+            ..Config::default()
+        };
+        assert_eq!(cfg.allow_tcp_ports(), &[32000, 8080]);
+        assert_eq!(Config::default().allow_tcp_ports(), &[] as &[u16]);
+    }
+
+    #[test]
+    fn parse_config_with_allow_tcp_ports() {
+        let toml = r#"
+command = ["opencode"]
+lockdown = true
+allow_tcp_ports = [32000, 8080]
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.allow_tcp_ports, vec![32000, 8080]);
     }
 
     #[test]
@@ -1093,6 +1194,7 @@ no_status_bar = false
             status_bar_style: None,
             no_seccomp: None,
             no_rlimits: None,
+            allow_tcp_ports: vec![32000],
         };
         save(&config);
 
@@ -1101,6 +1203,7 @@ no_status_bar = false
         assert_eq!(loaded.rw_maps, vec![PathBuf::from("/tmp/shared")]);
         assert_eq!(loaded.no_gpu, Some(true));
         assert_eq!(loaded.lockdown, Some(false));
+        assert_eq!(loaded.allow_tcp_ports, vec![32000]);
 
         // Cleanup
         std::env::set_current_dir(&original_dir).unwrap();

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -111,6 +111,7 @@ impl MountSet {
         &self,
         project_dir: &Path,
         lockdown: bool,
+        allow_tcp_ports: &[u16],
     ) -> Vec<String> {
         let mut args = vec![
             "--chdir".into(),
@@ -128,7 +129,9 @@ impl MountSet {
         }
 
         if lockdown {
-            args.push("--unshare-net".into());
+            if allow_tcp_ports.is_empty() {
+                args.push("--unshare-net".into());
+            }
             args.push("--clearenv".into());
 
             args.extend([
@@ -517,6 +520,11 @@ fn landlock_wrapper_args(config: &Config, verbose: bool) -> Vec<String> {
         "--no-display".into()
     });
 
+    for port in config.allow_tcp_ports() {
+        args.push("--allow-tcp-port".into());
+        args.push(port.to_string());
+    }
+
     for path in &config.rw_maps {
         args.push("--rw-map".into());
         args.push(path.display().to_string());
@@ -573,7 +581,11 @@ pub fn build(
         }
     }
 
-    for arg in mount_set.isolation_args(project_dir, lockdown) {
+    for arg in mount_set.isolation_args(
+        project_dir,
+        lockdown,
+        config.allow_tcp_ports(),
+    ) {
         cmd.arg(arg);
     }
 
@@ -641,7 +653,11 @@ fn build_dry_run_args(
         args.extend(m.to_args());
     }
 
-    args.extend(mount_set.isolation_args(project_dir, lockdown));
+    args.extend(mount_set.isolation_args(
+        project_dir,
+        lockdown,
+        config.allow_tcp_ports(),
+    ));
 
     args.push("--".into());
 
@@ -1309,6 +1325,69 @@ mod tests {
             .windows(3)
             .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
         assert!(!has_tmp_bind);
+    }
+
+    #[test]
+    fn lockdown_with_allowed_ports_skips_unshare_net() {
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        config.allow_tcp_ports = vec![32000];
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let project = PathBuf::from("/home/user/project");
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !args.contains(&"--unshare-net".to_string()),
+            "lockdown with allowed ports must skip --unshare-net"
+        );
+        assert!(args.contains(&"--clearenv".to_string()));
+    }
+
+    #[test]
+    fn lockdown_without_allowed_ports_keeps_unshare_net() {
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let project = PathBuf::from("/home/user/project");
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            args.contains(&"--unshare-net".to_string()),
+            "lockdown without allowed ports must keep --unshare-net"
+        );
+    }
+
+    #[test]
+    fn lockdown_wrapper_forwards_allowed_ports() {
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        config.allow_tcp_ports = vec![32000, 8080];
+
+        let wrapper_args = landlock_wrapper_args(&config, false);
+        let port_args: Vec<_> = wrapper_args
+            .windows(2)
+            .filter(|w| w[0] == "--allow-tcp-port")
+            .map(|w| w[1].clone())
+            .collect();
+        assert_eq!(port_args, vec!["32000", "8080"]);
     }
 
     #[test]

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -45,8 +45,8 @@
 use crate::config::Config;
 use crate::output;
 use landlock::{
-    path_beneath_rules, Access, AccessFs, AccessNet, Ruleset, RulesetAttr,
-    RulesetCreatedAttr, RulesetStatus, ABI,
+    path_beneath_rules, Access, AccessFs, AccessNet, NetPort, Ruleset,
+    RulesetAttr, RulesetCreatedAttr, RulesetStatus, ABI,
 };
 use std::path::{Path, PathBuf};
 
@@ -68,7 +68,7 @@ pub fn apply(
         return Ok(());
     }
 
-    match do_apply(config, project_dir, verbose) {
+    let fs_result = match do_apply(config, project_dir, verbose) {
         Ok(status) => match status {
             RulesetStatus::FullyEnforced => {
                 output::info("Landlock: fully enforced");
@@ -76,7 +76,9 @@ pub fn apply(
             }
             RulesetStatus::PartiallyEnforced => {
                 if config.lockdown_enabled() {
-                    Err("Landlock: partially enforced in lockdown mode".into())
+                    Err("Landlock: partially enforced \
+                         in lockdown mode"
+                        .into())
                 } else {
                     output::info(
                         "Landlock: partially enforced \
@@ -87,7 +89,8 @@ pub fn apply(
             }
             RulesetStatus::NotEnforced => {
                 if config.lockdown_enabled() {
-                    Err("Landlock: not enforced in lockdown mode \
+                    Err("Landlock: not enforced in \
+                         lockdown mode \
                          (kernel too old, bwrap-only)"
                         .into())
                 } else {
@@ -101,7 +104,10 @@ pub fn apply(
         },
         Err(e) => {
             if config.lockdown_enabled() {
-                Err(format!("Landlock: failed to apply in lockdown mode ({e})"))
+                Err(format!(
+                    "Landlock: failed to apply in \
+                     lockdown mode ({e})"
+                ))
             } else {
                 output::warn(&format!(
                     "Landlock: failed to apply ({e}), \
@@ -110,7 +116,13 @@ pub fn apply(
                 Ok(())
             }
         }
-    }
+    };
+    fs_result?;
+
+    // V4 network rules are stacked as a separate ruleset so
+    // filesystem enforcement is preserved on kernels without
+    // V4 support.
+    apply_net_rules(config, verbose)
 }
 
 /// Collect paths that need read-only access and paths that
@@ -144,63 +156,115 @@ fn do_apply(
         .add_rules(path_beneath_rules(rw_paths, access_all))?
         .restrict_self()?;
 
-    // Stack a second ruleset for V4 network restrictions.
-    // This is separate from the filesystem ruleset so V3
-    // behavior is preserved on kernels without V4 support.
-    apply_net_rules(config, verbose);
-
     Ok(status.ruleset)
 }
 
 /// Apply Landlock V4 (kernel ≥ 6.5) network restrictions.
 ///
-/// In lockdown mode: handle BindTcp + ConnectTcp but add NO port
-/// rules → all TCP is denied. This is defense-in-depth alongside
-/// bwrap's --unshare-net (network namespace with no interfaces).
-/// Even if an attacker escapes the network namespace, Landlock
-/// still blocks TCP.
+/// In lockdown mode with no allowed ports: handle BindTcp +
+/// ConnectTcp but add NO port rules → all TCP is denied. This
+/// is defense-in-depth alongside bwrap's --unshare-net.
 ///
-/// In normal mode: no network restrictions via Landlock. Agents
-/// need outbound HTTP(S) for package downloads, API calls, etc.
+/// In lockdown mode with allowed ports: handle BindTcp +
+/// ConnectTcp and add NetPort rules for each allowed port
+/// (ConnectTcp only). Unlisted ports are denied. bwrap's
+/// --unshare-net is skipped so the sandbox shares the host
+/// network stack (otherwise allowed ports would be unreachable).
 ///
-/// Best-effort: silently skipped if kernel lacks V4 support.
-fn apply_net_rules(config: &Config, verbose: bool) {
+/// In normal mode: no network restrictions via Landlock.
+///
+/// Best-effort when no allowed ports: silently skipped if kernel
+/// lacks V4 support (--unshare-net provides the isolation).
+///
+/// Hard-fail when allowed ports are configured but V4 is
+/// unavailable: --unshare-net was already skipped so there
+/// would be no network restriction at all, violating lockdown's
+/// security guarantee.
+///
+/// LIMITATION: Landlock V4 only covers TCP. When allowed ports
+/// are configured, --unshare-net is skipped and UDP/ICMP traffic
+/// is unrestricted. Seccomp blocks raw/packet sockets but
+/// regular UDP datagrams can still be sent and received.
+fn apply_net_rules(config: &Config, verbose: bool) -> Result<(), String> {
     if !config.lockdown_enabled() {
-        // Normal mode: no network restrictions via Landlock.
-        return;
+        return Ok(());
     }
 
     let net_access = AccessNet::from_all(ABI_NET);
     if net_access.is_empty() {
-        return;
+        return Ok(());
     }
 
-    // Handle net access but add NO NetPort rules → all TCP
-    // bind/connect is denied (defense-in-depth alongside
-    // bwrap's --unshare-net).
-    match Ruleset::default()
+    let allowed = config.allow_tcp_ports();
+
+    let result = Ruleset::default()
         .handle_access(net_access)
         .and_then(|r| r.create())
-        .and_then(|r| r.restrict_self())
-    {
-        Ok(status) => {
-            if verbose {
-                let enforced = match status.ruleset {
-                    RulesetStatus::FullyEnforced => "fully enforced",
-                    RulesetStatus::PartiallyEnforced => "partially enforced",
-                    RulesetStatus::NotEnforced => "not enforced",
-                };
-                output::verbose(&format!(
-                    "Landlock V4 net: {enforced} (lockdown)"
-                ));
+        .and_then(|r| {
+            let mut created = r;
+            for &port in allowed {
+                created = created
+                    .add_rule(NetPort::new(port, AccessNet::ConnectTcp))?;
             }
-        }
-        Err(_) => {
+            created.restrict_self()
+        });
+
+    match result {
+        Ok(status) => {
+            let enforced = match status.ruleset {
+                RulesetStatus::FullyEnforced => "fully enforced",
+                RulesetStatus::PartiallyEnforced => "partially enforced",
+                RulesetStatus::NotEnforced => "not enforced",
+            };
+
+            if !allowed.is_empty() {
+                match status.ruleset {
+                    RulesetStatus::FullyEnforced => {}
+                    _ => {
+                        return Err(format!(
+                            "Landlock V4 net: {enforced} \
+                             — cannot guarantee port \
+                             allowlist (--unshare-net \
+                             was skipped)"
+                        ));
+                    }
+                }
+            }
+
             if verbose {
-                output::verbose(
-                    "Landlock V4 net: unavailable \
-                     (kernel < 6.5, using --unshare-net only)",
-                );
+                if allowed.is_empty() {
+                    output::verbose(&format!(
+                        "Landlock V4 net: {enforced} \
+                         (lockdown, all TCP denied)"
+                    ));
+                } else {
+                    output::verbose(&format!(
+                        "Landlock V4 net: {enforced} \
+                         (lockdown, allowed ports: \
+                         {allowed:?})"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if allowed.is_empty() {
+                if verbose {
+                    output::verbose(
+                        "Landlock V4 net: unavailable \
+                         (kernel < 6.5, using \
+                         --unshare-net only)",
+                    );
+                }
+                Ok(())
+            } else {
+                Err(format!(
+                    "Landlock V4 required for \
+                     --allow-tcp-port but unavailable \
+                     ({e}). Cannot enforce port \
+                     allowlist without network \
+                     namespace — refusing to start"
+                ))
             }
         }
     }
@@ -732,21 +796,46 @@ mod tests {
 
     #[test]
     fn apply_net_rules_normal_is_noop() {
-        // Normal mode should not apply any net restrictions.
         let config = Config::default();
         assert!(!config.lockdown_enabled());
-        // Must not panic or error
-        apply_net_rules(&config, true);
+        assert!(apply_net_rules(&config, true).is_ok());
     }
 
     #[test]
     fn apply_net_rules_lockdown_does_not_panic() {
-        // On macOS/kernels without V4, this is best-effort.
         let config = Config {
             lockdown: Some(true),
             ..Config::default()
         };
-        // Must not panic regardless of kernel support
-        apply_net_rules(&config, true);
+        // On macOS / kernels without V4: Ok (ABI_NET is empty).
+        // On Linux with V4: Ok (deny-all TCP).
+        let _ = apply_net_rules(&config, true);
+    }
+
+    #[test]
+    fn apply_net_rules_lockdown_with_ports() {
+        let config = Config {
+            lockdown: Some(true),
+            allow_tcp_ports: vec![32000, 8080],
+            ..Config::default()
+        };
+        // On macOS / kernels without V4 ABI: Ok (early return,
+        //   net_access is empty).
+        // On Linux with V4: Ok (NetPort rules applied).
+        // On Linux without V4 but with net ABI: Err (hard-fail
+        //   because --unshare-net was skipped).
+        let _ = apply_net_rules(&config, true);
+    }
+
+    #[test]
+    fn apply_net_rules_lockdown_empty_ports() {
+        let config = Config {
+            lockdown: Some(true),
+            allow_tcp_ports: vec![],
+            ..Config::default()
+        };
+        // Empty ports → same as no ports → best-effort V4 or
+        // fallback to --unshare-net only.
+        let _ = apply_net_rules(&config, true);
     }
 }

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -26,6 +26,12 @@ pub fn platform_notes(config: &Config) {
             "--no-display has no effect on macOS (Cocoa is system-level)",
         );
     }
+    if !config.allow_tcp_ports().is_empty() && config.lockdown_enabled() {
+        output::warn(
+            "--allow-tcp-port has no effect on macOS \
+             lockdown (seatbelt blocks all network)",
+        );
+    }
 }
 
 pub fn build(config: &Config, project_dir: &Path, verbose: bool) -> Command {


### PR DESCRIPTION
## Summary

- Adds `--allow-tcp-port <PORT>` (repeatable) to permit outbound TCP connections to specific ports in lockdown mode, addressing the MCP/Serena use case in #12
- When allowed ports are configured, bwrap skips `--unshare-net` and Landlock V4 `NetPort` rules restrict `ConnectTcp` to only the listed ports — all other TCP (connect + bind) is denied at kernel level
- Hard-fails if Landlock V4 is unavailable or not fully enforced, since `--unshare-net` was already skipped and there would be no network restriction otherwise
- When no ports are configured, lockdown behavior is unchanged (`--unshare-net` + best-effort Landlock V4 deny-all)

### Usage

```bash
# Config file
lockdown = true
allow_tcp_ports = [32000, 8080]

# CLI
ai-jail --lockdown --allow-tcp-port 32000 opencode
```

### Known limitation

Landlock V4 only covers TCP. When allowed ports are configured and `--unshare-net` is skipped, UDP/ICMP traffic is unrestricted (seccomp still blocks raw/packet sockets). This is documented in the source.

### Backward compatibility

- New `allow_tcp_ports` field uses `#[serde(default)]` — old config files without it parse correctly
- Regression test added for pre-existing config format
- `--allow-tcp-port` without `--lockdown` is a no-op (normal mode already allows all network)
- macOS: prints a warning that `--allow-tcp-port` has no effect in lockdown (seatbelt blocks all network)

## Test plan

- [x] `cargo test` — 164 tests pass
- [x] `cargo fmt --check` passes
- [x] CI passes on Linux
- [ ] Run `ai-jail --lockdown --allow-tcp-port 32000 bash` on Linux with kernel ≥ 6.5 — verify TCP connect to port 32000 succeeds, other ports are denied
- [ ] Run `ai-jail --lockdown bash` (no allowed ports) — verify network is fully blocked (unchanged behavior)
- [ ] Run `ai-jail --lockdown --allow-tcp-port 32000 bash` on kernel < 6.5 — verify hard-fail with clear error message

Closes #12