### PR TITLE
Fix status bar cursor offset on macOS

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -126,6 +126,13 @@ fn set_scroll_region(fd: i32, content_rows: u16) {
     write_all_raw(fd, seq.as_bytes());
 }
 
+/// Sync the vt100 cursor position into the status bar module
+/// so that `draw()` can restore the cursor via CUP.
+fn sync_statusbar_cursor(parser: &vt100::Parser) {
+    let (row, col) = parser.screen().cursor_position();
+    crate::statusbar::set_cursor_position(row + 1, col + 1);
+}
+
 fn io_loop(master: &OwnedFd, init_rows: u16, init_cols: u16) {
     let stdin_fd = std::io::stdin().as_raw_fd();
     let master_raw = master.as_raw_fd();
@@ -192,6 +199,7 @@ fn io_loop(master: &OwnedFd, init_rows: u16, init_cols: u16) {
                 was_alt_screen = on_alt;
 
                 // Redraw status bar, then notify child
+                sync_statusbar_cursor(&parser);
                 crate::statusbar::redraw();
                 resize_pty();
                 forward_sigwinch();
@@ -213,6 +221,7 @@ fn io_loop(master: &OwnedFd, init_rows: u16, init_cols: u16) {
         match poll(&mut fds, PollTimeout::from(100_u16)) {
             Ok(0) => {
                 if pending_redraw {
+                    sync_statusbar_cursor(&parser);
                     crate::statusbar::redraw();
                     pending_redraw = false;
                 }
@@ -314,6 +323,7 @@ fn io_loop(master: &OwnedFd, init_rows: u16, init_cols: u16) {
                 write_all_raw(stdout, &diff);
                 // Reset scroll region before exit
                 write_all_raw(stdout, b"\x1b[r");
+                sync_statusbar_cursor(&parser);
                 crate::statusbar::redraw();
                 break;
             }
@@ -325,6 +335,7 @@ fn io_loop(master: &OwnedFd, init_rows: u16, init_cols: u16) {
             Some(r) if r.contains(PollFlags::POLLIN)
         ) && pending_redraw
         {
+            sync_statusbar_cursor(&parser);
             crate::statusbar::redraw();
             pending_redraw = false;
         }

--- a/src/statusbar.rs
+++ b/src/statusbar.rs
@@ -23,6 +23,11 @@ static CMD_LEN: AtomicUsize = AtomicUsize::new(0);
 
 static UPDATE_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
+// Cursor position (1-based) for restore after draw.
+// Set by the PTY proxy before each redraw.
+static CURSOR_ROW: AtomicUsize = AtomicUsize::new(1);
+static CURSOR_COL: AtomicUsize = AtomicUsize::new(1);
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // U+2026 HORIZONTAL ELLIPSIS: 3 UTF-8 bytes, 1 visible column
@@ -156,6 +161,14 @@ pub fn is_active() -> bool {
     ACTIVE.load(Ordering::SeqCst)
 }
 
+/// Store the cursor position (1-based) so `draw()` can restore it
+/// via absolute CUP instead of DECSC/DECRC. Must be called before
+/// `redraw()` whenever the PTY proxy knows the current position.
+pub fn set_cursor_position(row: u16, col: u16) {
+    CURSOR_ROW.store(row as usize, Ordering::SeqCst);
+    CURSOR_COL.store(col as usize, Ordering::SeqCst);
+}
+
 /// Request a redraw from async contexts.
 pub fn request_redraw() {
     DIRTY.store(true, Ordering::SeqCst);
@@ -268,8 +281,12 @@ fn draw(rows: u16, cols: u16) {
         }};
     }
 
-    // 1. Save cursor
-    put!(b"\x1b7");
+    // 1. Read the saved cursor position for CUP restore.
+    //    Avoids DECSC/DECRC (\x1b7/\x1b8) which on macOS terminals
+    //    also save/restore scroll margins AND clobber the child's
+    //    DECSC save slot, causing cursor offset artifacts.
+    let restore_row = CURSOR_ROW.load(Ordering::SeqCst) as u16;
+    let restore_col = CURSOR_COL.load(Ordering::SeqCst) as u16;
 
     // 2. Move to last row + clear it: \x1b[{rows};1H\x1b[2K
     put!(b"\x1b[");
@@ -421,8 +438,12 @@ fn draw(rows: u16, cols: u16) {
     // 6. Reset attributes
     put!(b"\x1b[0m");
 
-    // 7. Restore cursor
-    put!(b"\x1b8");
+    // 7. Restore cursor via absolute CUP (no DECRC).
+    put!(b"\x1b[");
+    pos += write_u16(restore_row, &mut buf[pos..]);
+    put!(b";");
+    pos += write_u16(restore_col, &mut buf[pos..]);
+    put!(b"H");
 
     raw_write(&buf[..pos]);
 }


### PR DESCRIPTION
## Summary

- The status bar `draw()` used `\x1b7`/`\x1b8` (DECSC/DECRC) to save/restore the cursor around drawing. On macOS terminals (Terminal.app, iTerm2) these also save/restore **scroll margins**, and they clobber the child's DECSC save slot — causing the input text buffer to render at the wrong position (offset/overlay on the CLI UI).
- Replaced with explicit CUP (`\x1b[row;colH`) cursor restore using the position tracked by the vt100 virtual terminal, matching the approach already used in `pty.rs` since commit d3ad05a.
- The PTY proxy now syncs the vt100 cursor position into the status bar module before each redraw via `set_cursor_position()`.

## Test plan

- [x] All 158 existing tests pass (`cargo test`)
- [x] Manual test: run `ai-jail claude` on macOS — verify input text no longer overlaps the CLI UI
- [x] Manual test: resize terminal while running — verify status bar and cursor stay correct
- [ ] Manual test: run on Linux — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)