### PR TITLE
feat: add --hide-dotdir option to hide sensitive directories from san…

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ COMMANDS (positional):
 OPTIONS:
     --rw-map <PATH>         Mount PATH read-write inside sandbox (repeatable)
     --map <PATH>            Mount PATH read-only inside sandbox (repeatable)
+    --hide-dotdir <NAME>    Never mount dotdir NAME (e.g., .my_secrets) (repeatable)
     --lockdown / --no-lockdown Enable/disable strict read-only lockdown mode
     --landlock / --no-landlock Enable/disable Landlock LSM (Linux 5.13+, default: on)
     --seccomp / --no-seccomp   Enable/disable seccomp syscall filter (Linux, default: on)
@@ -41,6 +42,7 @@ pub struct CliArgs {
     pub command: Vec<String>,
     pub rw_maps: Vec<PathBuf>,
     pub ro_maps: Vec<PathBuf>,
+    pub hide_dotdirs: Vec<String>,
     pub lockdown: Option<bool>,
     pub landlock: Option<bool>,
     pub seccomp: Option<bool>,
@@ -83,6 +85,21 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
                 let val: PathBuf =
                     parser.value().map_err(|e| e.to_string())?.into();
                 args.ro_maps.push(val);
+            }
+            Long("hide-dotdir") => {
+                let val = parser.value().map_err(|e| e.to_string())?;
+                let s = val.to_string_lossy().into_owned();
+                if s.is_empty() {
+                    return Err(
+                        "--hide-dotdir requires a non-empty value".into()
+                    );
+                }
+                let normalized = if s.starts_with('.') {
+                    s
+                } else {
+                    format!(".{}", s)
+                };
+                args.hide_dotdirs.push(normalized);
             }
             Long("lockdown") => args.lockdown = Some(true),
             Long("no-lockdown") => args.lockdown = Some(false),
@@ -342,6 +359,66 @@ mod tests {
         assert_eq!(args.ro_maps, vec![PathBuf::from("/opt/c")]);
     }
 
+    // ── Hide dotdir tests ────────────────────────────────────────
+
+    #[test]
+    fn parse_hide_dotdir() {
+        let args =
+            parse_test(&["--hide-dotdir", ".my_secrets", "bash"]).unwrap();
+        assert_eq!(args.hide_dotdirs, vec![".my_secrets"]);
+    }
+
+    #[test]
+    fn parse_multiple_hide_dotdirs() {
+        let args = parse_test(&[
+            "--hide-dotdir",
+            ".my_secrets",
+            "--hide-dotdir",
+            ".proton",
+            "bash",
+        ])
+        .unwrap();
+        assert_eq!(args.hide_dotdirs, vec![".my_secrets", ".proton"]);
+    }
+
+    #[test]
+    fn parse_hide_dotdir_with_maps() {
+        let args = parse_test(&[
+            "--hide-dotdir",
+            ".aws",
+            "--rw-map",
+            "/tmp/test",
+            "--map",
+            "/opt/data",
+            "bash",
+        ])
+        .unwrap();
+        assert_eq!(args.hide_dotdirs, vec![".aws"]);
+        assert_eq!(args.rw_maps, vec![PathBuf::from("/tmp/test")]);
+        assert_eq!(args.ro_maps, vec![PathBuf::from("/opt/data")]);
+    }
+
+    #[test]
+    fn parse_hide_dotdir_normalizes_no_dot() {
+        let args =
+            parse_test(&["--hide-dotdir", "my_secrets", "bash"]).unwrap();
+        assert_eq!(args.hide_dotdirs, vec![".my_secrets"]);
+    }
+
+    #[test]
+    fn parse_hide_dotdir_keeps_existing_dot() {
+        let args =
+            parse_test(&["--hide-dotdir", ".my_secrets", "bash"]).unwrap();
+        assert_eq!(args.hide_dotdirs, vec![".my_secrets"]);
+    }
+
+    #[test]
+    fn parse_hide_dotdir_empty_errors() {
+        let result = parse_test(&["--hide-dotdir", "", "bash"]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("non-empty"));
+    }
+
     // ── Combined flags ─────────────────────────────────────────
 
     #[test]
@@ -405,6 +482,12 @@ mod tests {
     #[test]
     fn parse_rw_map_missing_value_errors() {
         let result = parse_test(&["--rw-map"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_hide_dotdir_missing_value_errors() {
+        let result = parse_test(&["--hide-dotdir"]);
         assert!(result.is_err());
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     #[serde(default)]
     pub ro_maps: Vec<PathBuf>,
     #[serde(default)]
+    pub hide_dotdirs: Vec<String>,
+    #[serde(default)]
     pub no_gpu: Option<bool>,
     #[serde(default)]
     pub no_docker: Option<bool>,
@@ -134,6 +136,8 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     dedup_paths(&mut c.rw_maps);
     c.ro_maps.extend(local.ro_maps);
     dedup_paths(&mut c.ro_maps);
+    c.hide_dotdirs.extend(local.hide_dotdirs);
+    dedup_strings(&mut c.hide_dotdirs);
     if local.no_gpu.is_some() {
         c.no_gpu = local.no_gpu;
     }
@@ -277,6 +281,11 @@ fn dedup_paths(paths: &mut Vec<PathBuf>) {
     paths.retain(|p| seen.insert(p.clone()));
 }
 
+fn dedup_strings(strings: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    strings.retain(|s| seen.insert(s.clone()));
+}
+
 pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     let mut config = existing;
 
@@ -291,6 +300,10 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
 
     config.ro_maps.extend(cli.ro_maps.iter().cloned());
     dedup_paths(&mut config.ro_maps);
+
+    // hide_dotdirs: CLI values appended, deduplicated
+    config.hide_dotdirs.extend(cli.hide_dotdirs.iter().cloned());
+    dedup_strings(&mut config.hide_dotdirs);
 
     // Boolean flags: CLI overrides config (--no-gpu => no_gpu=Some(true), --gpu => no_gpu=Some(false))
     if let Some(v) = cli.gpu {
@@ -362,6 +375,12 @@ pub fn display_status(config: &Config) {
                 .map(|p| p.display().to_string())
                 .collect::<Vec<_>>()
                 .join(", "),
+        );
+    }
+    if !config.hide_dotdirs.is_empty() {
+        output::status_header(
+            "  Hide dotdirs",
+            &config.hide_dotdirs.join(", "),
         );
     }
 
@@ -583,6 +602,26 @@ no_status_bar = false
     }
 
     #[test]
+    fn regression_v0_6_0_config_without_hide_dotdirs() {
+        // v0.6.0 configs don't have hide_dotdirs field.
+        // They must still parse and default to empty.
+        let toml = r#"
+command = ["claude"]
+rw_maps = []
+ro_maps = []
+no_gpu = false
+no_docker = false
+lockdown = false
+no_landlock = false
+no_status_bar = false
+no_seccomp = false
+no_rlimits = false
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert!(cfg.hide_dotdirs.is_empty());
+    }
+
+    #[test]
     fn regression_empty_config_file() {
         // An empty .ai-jail file must not crash
         let cfg = parse_toml("").unwrap();
@@ -604,6 +643,7 @@ no_status_bar = false
             command: vec!["claude".into()],
             rw_maps: vec![PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")],
             ro_maps: vec![PathBuf::from("/opt/data")],
+            hide_dotdirs: vec![".my_secrets".into(), ".proton".into()],
             no_gpu: Some(true),
             no_docker: None,
             no_display: Some(false),
@@ -620,6 +660,7 @@ no_status_bar = false
         assert_eq!(deserialized.command, config.command);
         assert_eq!(deserialized.rw_maps, config.rw_maps);
         assert_eq!(deserialized.ro_maps, config.ro_maps);
+        assert_eq!(deserialized.hide_dotdirs, config.hide_dotdirs);
         assert_eq!(deserialized.no_gpu, config.no_gpu);
         assert_eq!(deserialized.no_docker, config.no_docker);
         assert_eq!(deserialized.no_display, config.no_display);
@@ -692,6 +733,36 @@ no_status_bar = false
         assert_eq!(
             merged.ro_maps,
             vec![PathBuf::from("/opt/x"), PathBuf::from("/opt/y")]
+        );
+    }
+
+    #[test]
+    fn merge_hide_dotdirs_appended_and_deduplicated() {
+        let existing = Config {
+            hide_dotdirs: vec![".my_secrets".into(), ".proton".into()],
+            ..Config::default()
+        };
+        let cli = CliArgs {
+            hide_dotdirs: vec![".proton".into(), ".password-store".into()],
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(
+            merged.hide_dotdirs,
+            vec![".my_secrets", ".proton", ".password-store"]
+        );
+    }
+
+    #[test]
+    fn parse_hide_dotdirs() {
+        let toml = r#"
+command = ["claude"]
+hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(
+            cfg.hide_dotdirs,
+            vec![".my_secrets", ".proton", ".password-store"]
         );
     }
 
@@ -824,6 +895,26 @@ no_status_bar = false
         let mut paths: Vec<PathBuf> = vec![];
         dedup_paths(&mut paths);
         assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn dedup_strings_removes_duplicates_preserves_order() {
+        let mut strings = vec![
+            ".my_secrets".into(),
+            ".proton".into(),
+            ".my_secrets".into(),
+            ".aws".into(),
+            ".proton".into(),
+        ];
+        dedup_strings(&mut strings);
+        assert_eq!(strings, vec![".my_secrets", ".proton", ".aws"]);
+    }
+
+    #[test]
+    fn dedup_strings_empty() {
+        let mut strings: Vec<String> = vec![];
+        dedup_strings(&mut strings);
+        assert!(strings.is_empty());
     }
 
     // ── Accessor method tests ─────────────────────────────────
@@ -1125,6 +1216,7 @@ no_status_bar = false
             command: vec!["codex".into()],
             rw_maps: vec![PathBuf::from("/tmp/shared")],
             ro_maps: vec![],
+            hide_dotdirs: vec![],
             no_gpu: Some(true),
             no_docker: None,
             no_display: None,

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -743,7 +743,11 @@ fn discover_mounts(
     MountSet {
         base: discover_base(hosts_file, resolv_mount),
         sys_masks: discover_sys_masks(lockdown),
-        home_dotfiles: discover_home_dotfiles(lockdown, verbose),
+        home_dotfiles: discover_home_dotfiles(
+            lockdown,
+            &config.hide_dotdirs,
+            verbose,
+        ),
         config_hide: if lockdown {
             vec![]
         } else {
@@ -860,7 +864,11 @@ fn discover_base(
     mounts
 }
 
-fn discover_home_dotfiles(lockdown: bool, verbose: bool) -> Vec<Mount> {
+fn discover_home_dotfiles(
+    lockdown: bool,
+    hide_dotdirs: &[String],
+    verbose: bool,
+) -> Vec<Mount> {
     let home = super::home_dir();
     let mut mounts = vec![Mount::Tmpfs { dest: home.clone() }];
 
@@ -888,7 +896,7 @@ fn discover_home_dotfiles(lockdown: bool, verbose: bool) -> Vec<Mount> {
             continue;
         }
 
-        if super::DOTDIR_DENY.contains(&name_str.as_ref()) {
+        if super::is_dotdir_denied(&name_str, hide_dotdirs) {
             if verbose {
                 output::verbose(&format!("deny: {}", path.display()));
             }
@@ -1313,7 +1321,7 @@ mod tests {
 
     #[test]
     fn lockdown_skips_host_home_dotfiles() {
-        let mounts = discover_home_dotfiles(true, false);
+        let mounts = discover_home_dotfiles(true, &[], false);
         assert_eq!(mounts.len(), 1, "lockdown should only mount tmpfs home");
         match &mounts[0] {
             Mount::Tmpfs { .. } => {}

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -45,8 +45,8 @@
 use crate::config::Config;
 use crate::output;
 use landlock::{
-    ABI, Access, AccessFs, AccessNet, Ruleset, RulesetAttr, RulesetCreatedAttr,
-    RulesetStatus, path_beneath_rules,
+    path_beneath_rules, Access, AccessFs, AccessNet, Ruleset, RulesetAttr,
+    RulesetCreatedAttr, RulesetStatus, ABI,
 };
 use std::path::{Path, PathBuf};
 
@@ -350,7 +350,7 @@ fn collect_normal_paths(
     // .ssh, .gnupg are denied entirely (never bind-mounted by
     // bwrap, so Landlock allowing them is moot — but we still
     // skip them for defense-in-depth). Everything else is ro.
-    collect_home_paths(&home, &mut ro, &mut rw, verbose);
+    collect_home_paths(&home, &config.hide_dotdirs, &mut ro, &mut rw, verbose);
 
     // $HOME/.local: read-write — mise, pipx, and other tools
     // store binaries and state here.
@@ -468,14 +468,15 @@ fn collect_normal_paths(
 
 /// Classify home dotdirs into read-only or read-write.
 ///
-/// Sensitive dirs (DOTDIR_DENY: .ssh, .gnupg, etc.) are skipped
-/// entirely — bwrap never bind-mounts them, so they are invisible
-/// inside the sandbox. Writable dirs (DOTDIR_RW: .cargo, .npm,
-/// .cache, etc.) are tool caches that agents legitimately modify.
+/// Sensitive dirs (DOTDIR_DENY: .ssh, .gnupg, etc.) and user-specified
+/// hide_dotdirs are skipped entirely — bwrap never bind-mounts them, so
+/// they are invisible inside the sandbox. Writable dirs (DOTDIR_RW: .cargo,
+/// .npm, .cache, etc.) are tool caches that agents legitimately modify.
 /// Everything else defaults to read-only (safe to read config
 /// from but not modify).
 fn collect_home_paths(
     home: &Path,
+    hide_dotdirs: &[String],
     ro: &mut Vec<PathBuf>,
     rw: &mut Vec<PathBuf>,
     verbose: bool,
@@ -497,7 +498,7 @@ fn collect_home_paths(
             continue;
         }
 
-        if super::DOTDIR_DENY.contains(&name_str.as_ref()) {
+        if super::is_dotdir_denied(&name_str, hide_dotdirs) {
             continue;
         }
 

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -28,6 +28,58 @@ const DOTDIR_DENY: &[&str] = &[
     ".sparrow",
 ];
 
+/// Returns true if the dotdir name requires read-write access.
+/// `name` should be the dotdir name with or without leading dot (e.g., ".cargo" or "cargo").
+fn is_dotdir_rw(name: &str) -> bool {
+    let normalized = name.strip_prefix('.').unwrap_or(name);
+    DOTDIR_RW
+        .iter()
+        .any(|&d| d.strip_prefix('.').unwrap_or(d) == normalized)
+}
+
+/// Returns true if the dotdir name is in the deny list.
+/// Checks both built-in DOTDIR_DENY and user-specified extras.
+/// `name` should be the dotdir name with or without leading dot (e.g., ".aws" or "aws").
+/// If user tries to deny a built-in RW directory, warns and returns false.
+#[expect(dead_code)]
+pub fn is_dotdir_denied(name: &str, extra: &[String]) -> bool {
+    let normalized = name.strip_prefix('.').unwrap_or(name);
+    // Check built-in list
+    if DOTDIR_DENY
+        .iter()
+        .any(|&d| d.strip_prefix('.').unwrap_or(d) == normalized)
+    {
+        return true;
+    }
+    // Check user-specified extras, but reject RW-required dirs
+    for e in extra {
+        let e_normalized = e.strip_prefix('.').unwrap_or(e);
+        if e_normalized == normalized {
+            if is_dotdir_rw(normalized) {
+                crate::output::warn(&format!(
+                    "Cannot hide {e}: it is required for sandboxed tool operation"
+                ));
+                return false;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns an iterator over all denied dotdir names (without leading dot).
+/// Includes both built-in DOTDIR_DENY and user-specified extras.
+pub fn denied_dotdirs(extra: &[String]) -> impl Iterator<Item = String> + '_ {
+    DOTDIR_DENY
+        .iter()
+        .map(|s| s.strip_prefix('.').unwrap_or(s).to_string())
+        .chain(
+            extra
+                .iter()
+                .map(|s| s.strip_prefix('.').unwrap_or(s).to_string()),
+        )
+}
+
 // Dotdirs requiring read-write access
 const DOTDIR_RW: &[&str] = &[
     ".claude",
@@ -73,7 +125,11 @@ fn mise_bin() -> Option<PathBuf> {
     std::env::var("PATH").ok().and_then(|paths| {
         paths.split(':').find_map(|dir| {
             let p = PathBuf::from(dir).join("mise");
-            if p.is_file() { Some(p) } else { None }
+            if p.is_file() {
+                Some(p)
+            } else {
+                None
+            }
         })
     })
 }
@@ -340,5 +396,74 @@ mod tests {
                 "{name} is in both deny and rw lists"
             );
         }
+    }
+
+    #[test]
+    fn is_dotdir_denied_builtin() {
+        assert!(is_dotdir_denied(".gnupg", &[]));
+        assert!(is_dotdir_denied("gnupg", &[])); // Without dot
+        assert!(is_dotdir_denied(".aws", &[]));
+        assert!(is_dotdir_denied(".ssh", &[]));
+        assert!(is_dotdir_denied(".mozilla", &[]));
+        assert!(is_dotdir_denied(".basilisk-dev", &[]));
+        assert!(is_dotdir_denied(".sparrow", &[]));
+    }
+
+    #[test]
+    fn is_dotdir_denied_extra() {
+        let extra = vec![".my_secrets".into(), ".proton".into()];
+        assert!(is_dotdir_denied(".my_secrets", &extra));
+        assert!(is_dotdir_denied("my_secrets", &extra)); // Without dot
+        assert!(is_dotdir_denied(".proton", &extra));
+        assert!(is_dotdir_denied("proton", &extra));
+    }
+
+    #[test]
+    fn is_dotdir_denied_not_in_list() {
+        assert!(!is_dotdir_denied(".cargo", &[]));
+        assert!(!is_dotdir_denied(".config", &[]));
+        assert!(!is_dotdir_denied(".my_custom", &[]));
+    }
+
+    #[test]
+    fn is_dotdir_denied_combined() {
+        let extra = vec![".my_secrets".into()];
+        // Built-in
+        assert!(is_dotdir_denied(".aws", &extra));
+        // Extra
+        assert!(is_dotdir_denied(".my_secrets", &extra));
+        // Not denied
+        assert!(!is_dotdir_denied(".cargo", &extra));
+    }
+
+    #[test]
+    fn cannot_deny_rw_required_dirs() {
+        for name in &[".cargo", ".cache", ".config", ".claude"] {
+            let extra = vec![name.to_string()];
+            assert!(
+                !is_dotdir_denied(name, &extra),
+                "{name} should not be deniable - it's RW-required"
+            );
+        }
+    }
+
+    #[test]
+    fn is_dotdir_rw_check() {
+        assert!(is_dotdir_rw(".cargo"));
+        assert!(is_dotdir_rw("cargo"));
+        assert!(is_dotdir_rw(".config"));
+        assert!(is_dotdir_rw(".cache"));
+        assert!(!is_dotdir_rw(".aws"));
+        assert!(!is_dotdir_rw(".my_secrets"));
+    }
+
+    #[test]
+    fn denied_dotdirs_iter() {
+        let extra: Vec<String> = vec![".my_secrets".into(), ".proton".into()];
+        let denied: Vec<String> = denied_dotdirs(&extra).collect();
+        assert!(denied.contains(&"gnupg".to_string()));
+        assert!(denied.contains(&"aws".to_string()));
+        assert!(denied.contains(&"my_secrets".to_string()));
+        assert!(denied.contains(&"proton".to_string()));
     }
 }

--- a/src/sandbox/rlimits.rs
+++ b/src/sandbox/rlimits.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::output;
-use nix::sys::resource::{Resource, getrlimit, setrlimit};
+use nix::sys::resource::{getrlimit, setrlimit, Resource};
 
 // Normal mode: generous limits that prevent abuse
 // without breaking build tools or AI agents.

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -127,7 +127,7 @@ fn generate_sbpl_profile(
     enable_docker: bool,
     lockdown: bool,
 ) -> String {
-    let deny_paths = macos_read_deny_paths();
+    let deny_paths = macos_read_deny_paths(&config.hide_dotdirs);
     let writable_paths = macos_writable_paths(project_dir, config, lockdown);
 
     let mut profile = String::new();
@@ -283,12 +283,11 @@ fn format_dry_run_macos(command_line: &str, profile: &str) -> String {
     out
 }
 
-fn macos_read_deny_paths() -> Vec<PathBuf> {
+fn macos_read_deny_paths(hide_dotdirs: &[String]) -> Vec<PathBuf> {
     let home = super::home_dir();
 
-    let mut candidates: Vec<PathBuf> = super::DOTDIR_DENY
-        .iter()
-        .map(|name| home.join(name))
+    let mut candidates: Vec<PathBuf> = super::denied_dotdirs(hide_dotdirs)
+        .map(|name| home.join(format!(".{}", name)))
         .collect();
 
     candidates.extend([
@@ -451,10 +450,8 @@ mod tests {
         let profile = generate_sbpl_profile(&config, &project, false, true);
         assert!(!profile.contains("(allow network-outbound)"));
         assert!(!profile.contains("(allow file-read*)\n"));
-        assert!(
-            profile
-                .contains("(allow file-read* (subpath \"/tmp/test-project\"))")
-        );
+        assert!(profile
+            .contains("(allow file-read* (subpath \"/tmp/test-project\"))"));
         // Lockdown should have no path-based write allowances (project, dotfiles, tmp)
         // but still allows device writes (/dev/null etc.) and PTY writes
         assert!(profile.contains("no host file-write allowances"));


### PR DESCRIPTION
…dbox

- Implement --hide-dotdir CLI flag to specify additional dotdirs to deny
- Add hide_dotdirs field to TOML config with CLI value merging
- Integrate with bwrap, Landlock, and seatbelt to hide directories on all platforms
- Implement automatic normalization (adds dot if missing) and deduplication
- Protect required RW directories (.cargo, .cache, .config) from being hidden
- Add regression tests for backward compatibility with v0.6.0 configs
- Update sandbox/mod.rs with utility functions is_dotdir_denied and denied_dotdirs

Refs: deny-dot-files-config