### PR TITLE
Fix lockdown error 11 EAGAIN (issue #21)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,14 @@ fn run_landlock_exec(cli: &cli::CliArgs) -> Result<i32, String> {
     // the filter.
     sandbox::apply_seccomp(&config, cli.verbose)?;
 
+    // Apply NPROC here, inside the sandbox, after bwrap has finished
+    // setting up namespaces. RLIMIT_NPROC counts all processes owned
+    // by the real UID system-wide, so setting it on the outer ai-jail
+    // before bwrap's clone() calls would cause EAGAIN when Chrome or
+    // other heavy applications are running.
+    #[cfg(target_os = "linux")]
+    sandbox::rlimits::apply_nproc(&config, cli.verbose);
+
     // Replace this process with the real command
     let err = std::process::Command::new(&cli.command[0])
         .args(&cli.command[1..])
@@ -171,8 +179,10 @@ fn run() -> Result<i32, String> {
     // sandbox after bwrap finishes mount namespace setup.
     let mut cmd = sandbox::build(&guard, &config, &project_dir, cli.verbose)?;
 
-    // Apply resource limits before spawning. Limits are inherited
-    // by the child across fork+exec.
+    // Apply NOFILE and CORE limits on the parent (inherited by child
+    // across fork+exec). NPROC is applied inside the sandbox instead
+    // — see run_landlock_exec() — to avoid EAGAIN during bwrap's
+    // internal clone() calls for namespace creation.
     sandbox::rlimits::apply(&config, cli.verbose);
 
     let exit_code = if use_status_bar {

--- a/src/sandbox/rlimits.rs
+++ b/src/sandbox/rlimits.rs
@@ -94,12 +94,15 @@ pub fn apply_nproc(config: &Config, verbose: bool) {
         return;
     };
     let effective = soft.min(hard);
-    if let Err(e) = setrlimit(Resource::RLIMIT_NPROC, effective, hard) {
+    // Set hard == soft so the sandboxed process cannot raise the
+    // limit back up. Lowering the hard limit is irreversible for
+    // unprivileged processes.
+    if let Err(e) = setrlimit(Resource::RLIMIT_NPROC, effective, effective) {
         output::warn(&format!("Failed to set RLIMIT_NPROC: {e}"));
     } else if verbose {
         output::verbose(&format!(
             "RLIMIT_NPROC: {} (hard: {})",
-            effective, hard
+            effective, effective
         ));
     }
 }

--- a/src/sandbox/rlimits.rs
+++ b/src/sandbox/rlimits.rs
@@ -39,21 +39,6 @@ fn limits_for(config: &Config) -> Vec<Limit> {
         },
     ];
 
-    // RLIMIT_NPROC is not exposed by nix on macOS
-    #[cfg(target_os = "linux")]
-    limits.insert(
-        0,
-        Limit {
-            resource: Resource::RLIMIT_NPROC,
-            soft: if lockdown {
-                NPROC_LOCKDOWN
-            } else {
-                NPROC_NORMAL
-            },
-            name: "NPROC",
-        },
-    );
-
     limits
 }
 
@@ -87,6 +72,35 @@ pub fn apply(config: &Config, verbose: bool) {
                 lim.name, effective, hard
             ));
         }
+    }
+}
+
+/// Apply RLIMIT_NPROC in the current process. Must be called inside
+/// the bwrap sandbox (from --landlock-exec), not on the bwrap parent:
+/// bwrap uses clone() for namespace creation, which counts against
+/// RLIMIT_NPROC system-wide. Applying the limit before bwrap's clone()
+/// causes EAGAIN when other user processes (e.g. Chrome) are running.
+#[cfg(target_os = "linux")]
+pub fn apply_nproc(config: &Config, verbose: bool) {
+    if !config.rlimits_enabled() {
+        return;
+    }
+    let soft = if config.lockdown_enabled() {
+        NPROC_LOCKDOWN
+    } else {
+        NPROC_NORMAL
+    };
+    let Ok((_, hard)) = getrlimit(Resource::RLIMIT_NPROC) else {
+        return;
+    };
+    let effective = soft.min(hard);
+    if let Err(e) = setrlimit(Resource::RLIMIT_NPROC, effective, hard) {
+        output::warn(&format!("Failed to set RLIMIT_NPROC: {e}"));
+    } else if verbose {
+        output::verbose(&format!(
+            "RLIMIT_NPROC: {} (hard: {})",
+            effective, hard
+        ));
     }
 }
 


### PR DESCRIPTION
Fixes #21 

---

#### » Current error
```
$ cat /etc/os-release | grep PRETTY
PRETTY_NAME="Ubuntu 24.04.4 LTS"

$ bwrap --version
bubblewrap 0.9.0

$ ai-jail --version
ai-jail 0.7.0

$ ulimit -u
126825

$ ai-jail --lockdown --verbose bash
▸ Lockdown mode enabled: read-only project, no host write mounts, no mise.
▸ Jail Active: /home/mshlz/experiments/ai-jail/test
  Status bar: off (use --no-status-bar to disable globally)
  RLIMIT_NPROC: 1024 (hard: 126825)
  RLIMIT_NOFILE: 4096 (hard: 1048576)
  RLIMIT_CORE: 0 (hard: 18446744073709551615)
✗ Failed to start sandbox: Resource temporarily unavailable (os error 11)

```

### After fix
---

#### » Test case 1 - Ensure limit
```bash
ai-jail --lockdown bash

# inside jail, should spawn ~1024 then print "bash: fork: retry: Resource temporarily unavailable"
while true; do sleep 10 & done
```

#### » Test case 2 - Ensure limit cannot be raised
```bash
ai-jail --lockdown bash

# inside jail
# show hard limit
ulimit -Hu

# show soft limit
ulimit -Su

# try raise limit, should fail with "bash: ulimit: max user processes: cannot modify limit: Operation not permitted"
ulimit -u 4096
```