### PR TITLE
feat: no-save-config toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ai-jail bash
 ai-jail --dry-run claude
 ```
 
-On first run, `ai-jail` creates a `.ai-jail` config file in the current directory. Subsequent runs reuse that config. Commit `.ai-jail` to your repo so the sandbox settings follow the project.
+On first run, `ai-jail` creates a `.ai-jail` config file in the current directory by default. Subsequent runs reuse that config. Commit `.ai-jail` to your repo so the sandbox settings follow the project. Use `--no-save-config` for ephemeral runs without creating or updating the project config.
 
 ## Security notes
 
@@ -137,6 +137,8 @@ This:
 - macOS: clears env to minimal allowlist, strips network and file-write rules from SBPL profile.
 
 Persistence: `--lockdown` alone doesn't write `.ai-jail` (keeps runs ephemeral). Persist it with `ai-jail --init --lockdown`. Undo with `--no-lockdown`.
+
+`--init` always writes config, so it cannot be combined with `--no-save-config`.
 
 ## What gets sandboxed
 
@@ -246,6 +248,7 @@ If no command is given and no `.ai-jail` config exists, defaults to `bash`.
 | `--docker` / `--no-docker` | Enable/disable Docker socket |
 | `--display` / `--no-display` | Enable/disable X11/Wayland |
 | `--mise` / `--no-mise` | Enable/disable mise integration |
+| `--save-config` / `--no-save-config` | Enable/disable automatic `.ai-jail` writes |
 | `-s`, `--status-bar[=STYLE]` | Enable persistent status line. `STYLE` is `dark` (default), `light`, or `pastel` (random pastel palette per session — use `=dark` / `=light` to switch back) |
 | `--no-status-bar` | Disable persistent status line |
 | `--exec` | Direct execution mode (no PTY proxy, no status bar) |
@@ -281,6 +284,9 @@ ai-jail --dry-run --verbose claude
 # Create config without running
 ai-jail --init --no-docker claude
 
+# Run without creating/updating .ai-jail
+ai-jail --no-save-config claude
+
 # Regenerate config from scratch
 ai-jail --clean --init claude
 
@@ -300,6 +306,7 @@ command = ["claude"]
 rw_maps = ["/home/user/Projects/shared-lib"]
 ro_maps = []
 no_gpu = true
+no_save_config = true
 lockdown = true
 ```
 
@@ -310,7 +317,8 @@ When CLI flags and an existing config are both present:
 - `command`: CLI replaces config for the current run, but a CLI-passed command is **not** auto-persisted when the project already has a stored command — so `ai-jail codex` after `ai-jail claude` runs codex for that session without rewriting `.ai-jail`'s stored default. Use `ai-jail --init <command>` to explicitly change the stored command. First-run bootstrap (no stored command yet) still persists the CLI command as the new default.
 - `rw_maps` / `ro_maps`: CLI values are appended (duplicates removed)
 - Boolean flags: CLI overrides config (`--no-gpu` sets `no_gpu = true`)
-- Config is updated after merge in normal mode; lockdown skips auto-save
+- `--save-config` / `--no-save-config` override `no_save_config`
+- Config is updated after merge in normal mode when config saving is enabled; lockdown skips auto-save
 
 ### Available fields
 
@@ -323,6 +331,7 @@ When CLI flags and an existing config are both present:
 | `no_docker` | bool | not set (auto) | `true` disables Docker socket |
 | `no_display` | bool | not set (auto) | `true` disables X11/Wayland |
 | `no_mise` | bool | not set (auto) | `true` disables mise integration |
+| `no_save_config` | bool | not set (enabled) | `true` disables automatic `.ai-jail` writes |
 | `no_landlock` | bool | not set (auto) | `true` disables Landlock LSM (Linux only) |
 | `no_seccomp` | bool | not set (auto) | `true` disables seccomp syscall filter (Linux only) |
 | `no_rlimits` | bool | not set (auto) | `true` disables resource limits |
@@ -330,7 +339,7 @@ When CLI flags and an existing config are both present:
 
 Status bar preferences (`no_status_bar`, `status_bar_style`) are stored in `$HOME/.ai-jail` (global user config), not in per-project `.ai-jail` files. `status_bar_style` accepts `"dark"`, `"light"`, or `"pastel"` — pastel rotates through a curated set of soft pastel palettes (with high-contrast foreground), picking a new one at random for each session. Set it back to `"dark"` or `"light"` to disable the rotation.
 
-When a boolean field is not set, the feature is enabled if the resource exists on the host.
+When a boolean field is not set, the feature is enabled if the resource exists on the host. `no_save_config` is the exception: when unset, config auto-save is enabled in normal mode.
 
 ## Windows
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,30 +14,31 @@ COMMANDS (positional):
     Any other string                       Passed through as the command
 
 OPTIONS:
-    --rw-map <PATH>         Mount PATH read-write inside sandbox (repeatable)
-    --map <PATH>            Mount PATH read-only inside sandbox (repeatable)
-    --hide-dotdir <NAME>    Never mount dotdir NAME (e.g., .my_secrets) (repeatable)
-    --lockdown / --no-lockdown Enable/disable strict read-only lockdown mode
-    --landlock / --no-landlock Enable/disable Landlock LSM (Linux 5.13+, default: on)
-    --seccomp / --no-seccomp   Enable/disable seccomp syscall filter (Linux, default: on)
-    --rlimits / --no-rlimits   Enable/disable resource limits (default: on)
-    --no-gpu / --gpu        Disable/enable GPU device passthrough (Linux only)
-    --no-docker / --docker  Disable/enable Docker socket passthrough
-    --no-display / --display Disable/enable X11/Wayland passthrough (Linux only)
-    --no-mise / --mise      Disable/enable mise integration
-    --save-config / --no-save-config Enable/disable automatic .ai-jail writes
-    -s, --status-bar[=STYLE] Set status line theme (dark | light | pastel; default dark)
-                            Pastel picks a random pastel palette per session
-    --no-status-bar          Disable persistent status line
-    --exec                   Direct execution mode (no PTY proxy, no status bar)
-    --allow-tcp-port <PORT> Allow outbound TCP to PORT in lockdown (repeatable)
-    --clean                 Ignore existing .ai-jail config, start fresh
-    --dry-run               Print the sandbox command without executing
-    --init                  Create/update .ai-jail config and exit
-    --bootstrap             Generate smart permission configs for AI tools
-    -v, --verbose           Show detailed mount info
-    -h, --help              Show help
-    -V, --version           Show version
+    --rw-map <PATH>                Mount PATH read-write inside sandbox (repeatable)
+    --map <PATH>                   Mount PATH read-only inside sandbox (repeatable)
+    --hide-dotdir <NAME>           Never mount dotdir NAME (e.g., .my_secrets) (repeatable)
+    --lockdown / --no-lockdown     Enable/disable strict read-only lockdown mode
+    --landlock / --no-landlock     Enable/disable Landlock LSM (Linux 5.13+, default: on)
+    --seccomp / --no-seccomp       Enable/disable seccomp syscall filter (Linux, default: on)
+    --rlimits / --no-rlimits       Enable/disable resource limits (default: on)
+    --no-gpu / --gpu               Disable/enable GPU device passthrough (Linux only)
+    --no-docker / --docker         Disable/enable Docker socket passthrough
+    --no-display / --display       Disable/enable X11/Wayland passthrough (Linux only)
+    --no-mise / --mise             Disable/enable mise integration
+    --save-config / --no-save-config
+                                   Enable/disable automatic .ai-jail writes
+    -s, --status-bar[=STYLE]       Set status line theme (dark | light | pastel; default dark)
+                                   Pastel picks a random pastel palette per session
+    --no-status-bar                Disable persistent status line
+    --exec                         Direct execution mode (no PTY proxy, no status bar)
+    --allow-tcp-port <PORT>        Allow outbound TCP to PORT in lockdown (repeatable)
+    --clean                        Ignore existing .ai-jail config, start fresh
+    --dry-run                      Print the sandbox command without executing
+    --init                         Create/update .ai-jail config and exit
+    --bootstrap                    Generate smart permission configs for AI tools
+    -v, --verbose                  Show detailed mount info
+    -h, --help                     Show help
+    -V, --version                  Show version
 ";
 
 #[derive(Debug, Default)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ OPTIONS:
     --no-docker / --docker  Disable/enable Docker socket passthrough
     --no-display / --display Disable/enable X11/Wayland passthrough (Linux only)
     --no-mise / --mise      Disable/enable mise integration
+    --save-config / --no-save-config Enable/disable automatic .ai-jail writes
     -s, --status-bar[=STYLE] Set status line theme (dark | light | pastel; default dark)
                             Pastel picks a random pastel palette per session
     --no-status-bar          Disable persistent status line
@@ -53,6 +54,7 @@ pub struct CliArgs {
     pub docker: Option<bool>,
     pub display: Option<bool>,
     pub mise: Option<bool>,
+    pub save_config: Option<bool>,
     pub status_bar: Option<bool>,
     pub status_bar_style: Option<String>,
     pub allow_tcp_ports: Vec<u16>,
@@ -131,6 +133,8 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
             Long("no-display") => args.display = Some(false),
             Long("mise") => args.mise = Some(true),
             Long("no-mise") => args.mise = Some(false),
+            Long("save-config") => args.save_config = Some(true),
+            Long("no-save-config") => args.save_config = Some(false),
             Long("status-bar") | Short('s') => {
                 if let Some(val) = parser.optional_value() {
                     let s = val.to_string_lossy();
@@ -343,6 +347,18 @@ mod tests {
     fn parse_mise() {
         let args = parse_test(&["--mise", "bash"]).unwrap();
         assert_eq!(args.mise, Some(true));
+    }
+
+    #[test]
+    fn parse_save_config() {
+        let args = parse_test(&["--save-config", "bash"]).unwrap();
+        assert_eq!(args.save_config, Some(true));
+    }
+
+    #[test]
+    fn parse_no_save_config() {
+        let args = parse_test(&["--no-save-config", "bash"]).unwrap();
+        assert_eq!(args.save_config, Some(false));
     }
 
     // ── Map flags ──────────────────────────────────────────────
@@ -678,5 +694,19 @@ mod tests {
     fn parse_last_wins_docker() {
         let args = parse_test(&["--docker", "--no-docker", "bash"]).unwrap();
         assert_eq!(args.docker, Some(false));
+    }
+
+    #[test]
+    fn parse_last_wins_save_config_enabled() {
+        let args =
+            parse_test(&["--no-save-config", "--save-config", "bash"]).unwrap();
+        assert_eq!(args.save_config, Some(true));
+    }
+
+    #[test]
+    fn parse_last_wins_save_config_disabled() {
+        let args =
+            parse_test(&["--save-config", "--no-save-config", "bash"]).unwrap();
+        assert_eq!(args.save_config, Some(false));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     #[serde(default)]
     pub no_mise: Option<bool>,
     #[serde(default)]
+    pub no_save_config: Option<bool>,
+    #[serde(default)]
     pub lockdown: Option<bool>,
     #[serde(default)]
     pub no_landlock: Option<bool>,
@@ -56,6 +58,9 @@ impl Config {
     }
     pub fn lockdown_enabled(&self) -> bool {
         self.lockdown == Some(true)
+    }
+    pub fn save_config_enabled(&self) -> bool {
+        self.no_save_config != Some(true)
     }
     pub fn landlock_enabled(&self) -> bool {
         self.no_landlock != Some(true)
@@ -155,6 +160,9 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     }
     if local.no_mise.is_some() {
         c.no_mise = local.no_mise;
+    }
+    if local.no_save_config.is_some() {
+        c.no_save_config = local.no_save_config;
     }
     if local.lockdown.is_some() {
         c.lockdown = local.lockdown;
@@ -327,6 +335,9 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     if let Some(v) = cli.mise {
         config.no_mise = Some(!v);
     }
+    if let Some(v) = cli.save_config {
+        config.no_save_config = Some(!v);
+    }
     if let Some(v) = cli.lockdown {
         config.lockdown = Some(v);
     }
@@ -409,6 +420,11 @@ pub fn display_status(config: &Config) {
     bool_opt("Docker", config.no_docker);
     bool_opt("Display", config.no_display);
     bool_opt("Mise", config.no_mise);
+    match config.no_save_config {
+        Some(true) => output::status_header("  Save config", "disabled"),
+        Some(false) => output::status_header("  Save config", "enabled"),
+        None => output::status_header("  Save config", "enabled (default)"),
+    }
     bool_opt("Landlock", config.no_landlock);
     bool_opt("Seccomp", config.no_seccomp);
     bool_opt("Rlimits", config.no_rlimits);
@@ -463,6 +479,7 @@ mod tests {
         assert!(cfg.rw_maps.is_empty());
         assert!(cfg.ro_maps.is_empty());
         assert_eq!(cfg.no_gpu, None);
+        assert_eq!(cfg.no_save_config, None);
         assert_eq!(cfg.lockdown, None);
     }
 
@@ -476,6 +493,7 @@ no_gpu = true
 no_docker = false
 no_display = true
 no_mise = false
+no_save_config = true
 lockdown = true
 "#;
         let cfg = parse_toml(toml).unwrap();
@@ -486,6 +504,7 @@ lockdown = true
         assert_eq!(cfg.no_docker, Some(false));
         assert_eq!(cfg.no_display, Some(true));
         assert_eq!(cfg.no_mise, Some(false));
+        assert_eq!(cfg.no_save_config, Some(true));
         assert_eq!(cfg.lockdown, Some(true));
     }
 
@@ -496,6 +515,18 @@ lockdown = true
         assert_eq!(cfg.command, vec!["bash"]);
         assert!(cfg.rw_maps.is_empty());
         assert_eq!(cfg.no_gpu, None);
+    }
+
+    #[test]
+    fn parse_no_save_config_false() {
+        let cfg = parse_toml("no_save_config = false").unwrap();
+        assert_eq!(cfg.no_save_config, Some(false));
+    }
+
+    #[test]
+    fn parse_no_save_config_true() {
+        let cfg = parse_toml("no_save_config = true").unwrap();
+        assert_eq!(cfg.no_save_config, Some(true));
     }
 
     #[test]
@@ -569,6 +600,7 @@ another_removed_field = true
         assert_eq!(cfg.no_docker, None);
         assert_eq!(cfg.no_display, None);
         assert_eq!(cfg.no_mise, None);
+        assert_eq!(cfg.no_save_config, None);
         assert_eq!(cfg.lockdown, None);
         assert_eq!(cfg.no_landlock, None);
         assert_eq!(cfg.no_status_bar, None);
@@ -699,6 +731,7 @@ no_rlimits = false
             no_docker: None,
             no_display: Some(false),
             no_mise: None,
+            no_save_config: Some(true),
             lockdown: Some(true),
             no_landlock: Some(false),
             no_status_bar: None,
@@ -717,6 +750,7 @@ no_rlimits = false
         assert_eq!(deserialized.no_docker, config.no_docker);
         assert_eq!(deserialized.no_display, config.no_display);
         assert_eq!(deserialized.no_mise, config.no_mise);
+        assert_eq!(deserialized.no_save_config, config.no_save_config);
         assert_eq!(deserialized.lockdown, config.lockdown);
         assert_eq!(deserialized.no_landlock, config.no_landlock);
         assert_eq!(deserialized.no_seccomp, config.no_seccomp);
@@ -850,6 +884,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
             no_docker: Some(false),
             no_display: None,
             no_mise: Some(true),
+            no_save_config: Some(true),
             lockdown: Some(true),
             no_landlock: Some(true),
             ..Config::default()
@@ -860,6 +895,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
         assert_eq!(merged.no_docker, Some(false));
         assert_eq!(merged.no_display, None);
         assert_eq!(merged.no_mise, Some(true));
+        assert_eq!(merged.no_save_config, Some(true));
         assert_eq!(merged.lockdown, Some(true));
         assert_eq!(merged.no_landlock, Some(true));
     }
@@ -868,11 +904,12 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
     fn merge_all_boolean_flags() {
         let existing = Config::default();
         let cli = CliArgs {
-            gpu: Some(false),     // --no-gpu
-            docker: Some(false),  // --no-docker
-            display: Some(true),  // --display
-            mise: Some(true),     // --mise
-            lockdown: Some(true), // --lockdown
+            gpu: Some(false),         // --no-gpu
+            docker: Some(false),      // --no-docker
+            display: Some(true),      // --display
+            mise: Some(true),         // --mise
+            save_config: Some(false), // --no-save-config
+            lockdown: Some(true),     // --lockdown
             ..CliArgs::default()
         };
         let merged = merge(&cli, existing);
@@ -880,6 +917,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
         assert_eq!(merged.no_docker, Some(true));
         assert_eq!(merged.no_display, Some(false));
         assert_eq!(merged.no_mise, Some(false));
+        assert_eq!(merged.no_save_config, Some(true));
         assert_eq!(merged.lockdown, Some(true));
     }
 
@@ -968,6 +1006,62 @@ allow_tcp_ports = [32000, 8080]
         };
         let merged = merge(&cli, existing);
         assert_eq!(merged.lockdown, Some(false));
+    }
+
+    #[test]
+    fn merge_with_global_local_no_save_config_wins_false() {
+        let global = Config {
+            no_save_config: Some(true),
+            ..Config::default()
+        };
+        let local = Config {
+            no_save_config: Some(false),
+            ..Config::default()
+        };
+        let merged = merge_with_global(global, local);
+        assert_eq!(merged.no_save_config, Some(false));
+    }
+
+    #[test]
+    fn merge_with_global_local_no_save_config_wins_true() {
+        let global = Config {
+            no_save_config: Some(false),
+            ..Config::default()
+        };
+        let local = Config {
+            no_save_config: Some(true),
+            ..Config::default()
+        };
+        let merged = merge_with_global(global, local);
+        assert_eq!(merged.no_save_config, Some(true));
+    }
+
+    #[test]
+    fn merge_cli_save_config_overrides_config() {
+        let existing = Config {
+            no_save_config: Some(true),
+            ..Config::default()
+        };
+        let cli = CliArgs {
+            save_config: Some(true),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(merged.no_save_config, Some(false));
+    }
+
+    #[test]
+    fn merge_cli_no_save_config_overrides_config() {
+        let existing = Config {
+            no_save_config: Some(false),
+            ..Config::default()
+        };
+        let cli = CliArgs {
+            save_config: Some(false),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(merged.no_save_config, Some(true));
     }
 
     // ── Dedup tests ────────────────────────────────────────────
@@ -1118,6 +1212,31 @@ allow_tcp_ports = [32000, 8080]
                 ..Config::default()
             }
             .mise_enabled()
+        );
+    }
+
+    #[test]
+    fn save_config_enabled_accessor() {
+        assert!(
+            Config {
+                no_save_config: None,
+                ..Config::default()
+            }
+            .save_config_enabled()
+        );
+        assert!(
+            !Config {
+                no_save_config: Some(true),
+                ..Config::default()
+            }
+            .save_config_enabled()
+        );
+        assert!(
+            Config {
+                no_save_config: Some(false),
+                ..Config::default()
+            }
+            .save_config_enabled()
         );
     }
 
@@ -1323,6 +1442,7 @@ allow_tcp_ports = [32000, 8080]
             no_docker: None,
             no_display: None,
             no_mise: None,
+            no_save_config: Some(true),
             lockdown: Some(false),
             no_landlock: None,
             no_status_bar: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,16 @@ fn run_landlock_exec(cli: &cli::CliArgs) -> Result<i32, String> {
     Err(format!("Failed to exec {}: {err}", cli.command[0]))
 }
 
+fn validate_write_flags(cli: &cli::CliArgs) -> Result<(), String> {
+    if cli.init && cli.save_config == Some(false) {
+        return Err("--init conflicts with --no-save-config".into());
+    }
+    Ok(())
+}
+
 fn run() -> Result<i32, String> {
     let cli = cli::parse()?;
+    validate_write_flags(&cli)?;
 
     // Suppress info/warn output in --exec mode for clean stdout
     if cli.exec {
@@ -133,7 +141,7 @@ fn run() -> Result<i32, String> {
     // and `ai-jail codex` on the same project and the stored default
     // should not flip under them. First-run bootstrap (no stored
     // command yet) still persists the CLI command as the new default.
-    if !config.lockdown_enabled() {
+    if !config.lockdown_enabled() && config.save_config_enabled() {
         let mut to_save = config.clone();
         if !stored_command.is_empty() && !cli.command.is_empty() {
             to_save.command = stored_command;
@@ -246,7 +254,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::command_needs_direct_tty;
+    use super::{command_needs_direct_tty, validate_write_flags};
+    use crate::cli::CliArgs;
 
     #[test]
     fn crush_requires_direct_tty() {
@@ -259,5 +268,43 @@ mod tests {
         assert!(!command_needs_direct_tty(&[]));
         assert!(!command_needs_direct_tty(&["codex".into()]));
         assert!(!command_needs_direct_tty(&["/usr/bin/bash".into()]));
+    }
+
+    #[test]
+    fn validate_write_flags_rejects_init_with_no_save_config() {
+        let cli = CliArgs {
+            init: true,
+            save_config: Some(false),
+            ..CliArgs::default()
+        };
+        assert!(validate_write_flags(&cli).is_err());
+    }
+
+    #[test]
+    fn validate_write_flags_allows_init_alone() {
+        let cli = CliArgs {
+            init: true,
+            ..CliArgs::default()
+        };
+        assert!(validate_write_flags(&cli).is_ok());
+    }
+
+    #[test]
+    fn validate_write_flags_allows_init_with_save_config() {
+        let cli = CliArgs {
+            init: true,
+            save_config: Some(true),
+            ..CliArgs::default()
+        };
+        assert!(validate_write_flags(&cli).is_ok());
+    }
+
+    #[test]
+    fn validate_write_flags_allows_no_save_config_alone() {
+        let cli = CliArgs {
+            save_config: Some(false),
+            ..CliArgs::default()
+        };
+        assert!(validate_write_flags(&cli).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- add `--save-config` / `--no-save-config` CLI switches
- persist the setting as `no_save_config` in `.ai-jail`
- skip automatic config writes when saving is disabled
- reject `--init` together with `--no-save-config`
- document and test the new behavior

## Design notes
- I used `no_save_config` instead of `save_config` in the config file to stay aligned with the existing negative boolean config naming pattern.
- I thought about using `--no-init`, but rejected it because `--init` means “write the config and exit,” which is an action rather than a true on/off toggle.
- I added an explicit check for `--init` with `--no-save-config` because those two options together would be confusing: one requests writing config, while the other disables it.
- The default remains to save config so existing behavior keeps working and backward compatibility is preserved.
