### PR TITLE
feat(bootstrap): allow ripgrep in generated Claude permissions

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -29,6 +29,7 @@ const ALLOW: &[&str] = &[
     "Bash(ls *)",
     "Bash(find *)",
     "Bash(grep *)",
+    "Bash(rg *)",
     "Bash(cat *)",
     "Bash(head *)",
     "Bash(tail *)",
@@ -614,6 +615,7 @@ mod tests {
 
         let allow = obj["allow"].as_array().unwrap();
         assert!(allow.iter().any(|v| v == "Bash(git status *)"));
+        assert!(allow.iter().any(|v| v == "Bash(rg *)"));
         assert!(allow.iter().any(|v| v == "WebSearch"));
 
         let deny = obj["deny"].as_array().unwrap();


### PR DESCRIPTION
Add ripgrep to the shared bootstrap allowlist used for generated Claude permissions.

AI coding agents routinely rely on rg for fast codebase search, so the generated profile should permit it out of the box instead of forcing a manual config edit.

Also extend the Claude permissions roundtrip test to assert that the generated allowlist includes the new rg entry.

Assisted-by: Codex (GPT-5)