### PR TITLE
test(bwrap): make --new-session assertion environment-dependent

### DIFF
--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -1333,7 +1333,12 @@ mod tests {
         assert!(args.contains(&"--unshare-pid".to_string()));
         assert!(args.contains(&"--unshare-uts".to_string()));
         assert!(args.contains(&"--unshare-ipc".to_string()));
-        assert!(args.contains(&"--new-session".to_string()));
+        // --new-session is environment-dependent; see should_use_new_session.
+        if should_use_new_session() {
+            assert!(args.contains(&"--new-session".to_string()));
+        } else {
+            assert!(!args.contains(&"--new-session".to_string()));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`sandbox::bwrap::tests::dry_run_contains_isolation_flags` asserts `--new-session` unconditionally, but the flag is added conditionally by `should_use_new_session()` at runtime. The test passes by accident in interactive developer shells and fails inside clean-chroot builders (Arch `pkgctl build` / `makechrootpkg`, `systemd-nspawn`). This PR applies the same guarded pattern the sibling test `new_session_when_not_interactive` already uses.

## Environment

| Component | Version |
|---|---|
| ai-jail | v0.8.3 (tag) |
| Build tool | `pkgctl` from `devtools 1:1.5.0-1` (Arch Linux) |
| Build isolation | `systemd-nspawn` clean chroot |
| Host OS | Arch Linux, kernel 6.19.11-arch1-1 |
| Rust | 1.94.1 (stable) |
| bubblewrap | 0.11.1 |

Also reproducible with `makechrootpkg -c -r /var/lib/archbuild/extra-x86_64`.

## Current behaviour

Inside a clean-chroot build, `cargo test` (invoked by the PKGBUILD `check()` phase) fails:

```
running 250 tests
...
failures:

---- sandbox::bwrap::tests::dry_run_contains_isolation_flags stdout ----
thread 'sandbox::bwrap::tests::dry_run_contains_isolation_flags' panicked at
  src/sandbox/bwrap.rs:1336:9:
assertion failed: args.contains(&"--new-session".to_string())

failures:
    sandbox::bwrap::tests::dry_run_contains_isolation_flags

test result: FAILED. 249 passed; 1 failed; 0 ignored; 0 measured
error: test failed, to rerun pass `--bin ai-jail`
==> ERROR: A failure occurred in check().
```

## Expected behaviour

`cargo test` passes in both interactive and non-interactive environments. The test's correctness should not depend on whether the caller's stdin happens to be a terminal.

## Root cause

The assertion is unconditional:

```rust
// src/sandbox/bwrap.rs:1336
assert!(args.contains(&"--new-session".to_string()));
```

But `--new-session` is only pushed onto the args vector when `should_use_new_session()` returns `true`:

```rust
fn should_use_new_session() -> bool {
    !crate::statusbar::is_active() && !std::io::stdin().is_terminal()
}
```

Whether `stdin().is_terminal()` is `true` at the point where the test runs depends on the environment:

- In a typical developer shell, `cargo test` redirects stdin → not a terminal → `should_use_new_session() == true` → flag present → test passes.
- Inside `systemd-nspawn` (how `pkgctl build` runs the test phase), stdin is a pseudo-terminal → `is_terminal() == true` → flag absent → test fails.

The sibling test `new_session_when_not_interactive` already handles this correctly:

```rust
if !std::io::stdin().is_terminal() {
    assert!(should_use_new_session());
}
```

## Fix

Assert the presence of `--new-session` conditional on what `should_use_new_session()` actually returns at test runtime, covering both branches:

```rust
// --new-session is environment-dependent; see should_use_new_session.
if should_use_new_session() {
    assert!(args.contains(&"--new-session".to_string()));
} else {
    assert!(!args.contains(&"--new-session".to_string()));
}
```

No change to production code — only the test itself.

## How to test

```bash
# On the host (interactive shell):
cargo test sandbox::bwrap::tests::dry_run_contains_isolation_flags
# → ok

# Inside pkgctl build / nspawn (previously FAILED):
pkgctl build
# → 250 passed, 0 failed; check() phase succeeds
```

## Notes

Found while preparing Arch Linux AUR packages (`ai-jail`, `ai-jail-bin`). Companion PR at #28 fixes a related issue in the integration test suite.
