### PR TITLE
fix(bwrap): always enforce --new-session in lockdown mode

### DIFF
--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -129,7 +129,7 @@ impl MountSet {
             "ai-sandbox".into(),
         ];
 
-        if should_use_new_session() {
+        if lockdown || should_use_new_session() {
             args.push("--new-session".into());
         }
 
@@ -1358,6 +1358,33 @@ mod tests {
                 && w[2] == "/home/user/project"
         });
         assert!(has_project_ro);
+    }
+
+    #[test]
+    fn lockdown_forces_new_session() {
+        // --new-session must be present in lockdown mode regardless of
+        // whether stdin is a terminal. The README documents lockdown as
+        // enabling --new-session unconditionally; should_use_new_session()
+        // alone is TTY-dependent, so lockdown needs its own short-circuit.
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let project = PathBuf::from("/home/user/project");
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            args.contains(&"--new-session".to_string()),
+            "--new-session must be present in lockdown mode regardless of stdin"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #30.

`--new-session` was documented in the README as always-on under `--lockdown`, but `should_use_new_session()` only looks at `stdin().is_terminal()` and `statusbar::is_active()`, so an interactive `ai-jail --lockdown bash` produced bwrap args without the flag.

`isolation_args()` already receives `lockdown: bool` — add it to the short-circuit so the flag is pushed whenever lockdown is on, independent of TTY.

## Fix

```rust
- if should_use_new_session() {
+ if lockdown || should_use_new_session() {
      args.push("--new-session".into());
  }
```

## Test

Adds `lockdown_forces_new_session`, a regression test that asserts `--new-session` is present in the bwrap args when `config.lockdown = Some(true)`, independent of stdin state. Sits alongside the existing `lockdown_project_is_read_only` test.

## How to verify

```bash
# On the host:
cargo test --bin ai-jail sandbox::bwrap::tests::lockdown_forces_new_session
# → ok

# Manual verification (before merge, without the fix):
script -qec "ai-jail --dry-run --lockdown bash" /dev/null 2>&1 | grep -c -- '--new-session'
# before the fix: 0
# after the fix:  1
```

## Notes

- 1-line production change in `isolation_args()`, plus the new test.
- No behaviour change outside lockdown mode.
- Found while preparing Arch Linux AUR packages (see #27, #28, #29).
