### PR TITLE
feat: support git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ ai-jail --dry-run claude
 
 On first run, `ai-jail` creates a `.ai-jail` config file in the current directory by default. Subsequent runs reuse that config. Commit `.ai-jail` to your repo so the sandbox settings follow the project. Use `--no-save-config` for ephemeral runs without creating or updating the project config.
 
+If you run `ai-jail` from a linked Git worktree, it auto-detects the worktree's external Git admin directories and exposes them safely inside the sandbox so `git status`, `git commit`, and similar commands keep working. Disable this with `--no-worktree` or `no_worktree = true`.
+
 ## Security notes
 
 The default mode favors usability over maximum lockdown. These are intentionally open by default:
@@ -145,6 +147,7 @@ This:
 - Disables GPU, Docker, display passthrough, and mise.
 - Ignores `--rw-map` and `--map` flags.
 - Mounts `$HOME` as bare tmpfs (no host dotfiles).
+- Still exposes validated linked Git worktree metadata read-only when needed, so read-only Git operations can work from linked worktrees.
 - Linux: `--clearenv` with minimal allowlist, `--unshare-net`, `--new-session`.
 - macOS: clears env to minimal allowlist, strips network and file-write rules from SBPL profile.
 
@@ -163,12 +166,13 @@ Persistence: `--lockdown` alone doesn't write `.ai-jail` (keeps runs ephemeral).
 | `/tmp`, `/run` | tmpfs | Fresh temp dirs per session |
 | `$HOME` | tmpfs | Empty home, then dotfiles layered on top |
 | Project directory (pwd) | **read-write** | The whole point |
+| Linked Git worktree metadata | auto passthrough | Validated `.git` gitfile targets are mounted when the current directory is a linked worktree |
 | GPU devices (`/dev/nvidia*`, `/dev/dri`) | device | For GPU-accelerated tools |
 | Docker socket | read-write | If `/var/run/docker.sock` exists |
 | X11/Wayland | passthrough | Display server access |
 | `/dev/shm` | device | Shared memory (Chromium needs this) |
 
-In `--lockdown`, project is mounted read-only and host write mounts are removed.
+In `--lockdown`, project is mounted read-only and host write mounts are removed. For linked Git worktrees, validated external Git metadata is still exposed read-only unless disabled with `--no-worktree`.
 
 ### Home directory handling
 
@@ -189,6 +193,7 @@ Your real `$HOME` is replaced with a tmpfs. Dotfiles and dotdirs are selectively
 **Explicit file mounts:**
 - `~/.gitconfig` (read-only)
 - `~/.claude.json` (read-write)
+- Validated linked Git worktree admin dirs outside the project tree (auto, same-path passthrough)
 
 **Local overrides (read-write):**
 - `~/.local/state`
@@ -205,7 +210,7 @@ On Linux 5.13+, ai-jail applies [Landlock](https://landlock.io/) restrictions as
 
 - Uses ABI V3 (Linux 6.2+) for filesystem rules with best-effort degradation to V1 on 5.13+ or no-op on older kernels.
 - On Linux 6.5+, a second V4 ruleset adds network restrictions: lockdown mode denies all TCP bind/connect (defense-in-depth alongside `--unshare-net`).
-- Applied in the parent process before spawning bwrap, so restrictions inherit through fork+exec.
+- Applied after bwrap namespace setup via an internal wrapper, so Landlock sees the final sandbox mount layout.
 - In `--lockdown`, Landlock rules are stricter: project is read-only, no home dotdirs, only `/tmp` is writable, no network.
 - Disable with `--no-landlock` if it causes issues with specific tools.
 
@@ -281,6 +286,7 @@ If no command is given and no `.ai-jail` config exists, defaults to `bash`.
 | `--gpu` / `--no-gpu` | Enable/disable GPU passthrough |
 | `--docker` / `--no-docker` | Enable/disable Docker socket |
 | `--display` / `--no-display` | Enable/disable X11/Wayland |
+| `--worktree` / `--no-worktree` | Enable/disable linked Git worktree metadata passthrough (default: on) |
 | `--mise` / `--no-mise` | Enable/disable mise integration |
 | `--ssh` / `--no-ssh` | Share `~/.ssh` read-only + forward `SSH_AUTH_SOCK` (default: off) |
 | `--pictures` / `--no-pictures` | Share `~/Pictures` read-only (default: off) |
@@ -307,6 +313,9 @@ ai-jail --map /opt/datasets claude
 
 # No GPU, no Docker, just the basics
 ai-jail --no-gpu --no-docker claude
+
+# Disable linked Git worktree passthrough for this run
+ai-jail --no-worktree claude
 
 # Run a one-shot command and capture its output
 result=$(ai-jail --exec -- my-script.sh --flag1 --flag2)
@@ -379,6 +388,7 @@ When CLI flags and an existing config are both present:
 | `no_gpu` | bool | not set (auto) | `true` disables GPU passthrough |
 | `no_docker` | bool | not set (auto) | `true` disables Docker socket |
 | `no_display` | bool | not set (auto) | `true` disables X11/Wayland |
+| `no_worktree` | bool | not set (auto) | `true` disables linked Git worktree metadata passthrough |
 | `no_mise` | bool | not set (auto) | `true` disables mise integration |
 | `ssh` | bool | not set (off) | `true` shares `~/.ssh` read-only + forwards `SSH_AUTH_SOCK` |
 | `pictures` | bool | not set (off) | `true` shares `~/Pictures` read-only |
@@ -390,7 +400,7 @@ When CLI flags and an existing config are both present:
 
 Status bar preferences (`no_status_bar`, `status_bar_style`, `resize_redraw_key`) are stored in `$HOME/.ai-jail` (global user config), not in per-project `.ai-jail` files. `status_bar_style` accepts `"dark"`, `"light"`, or `"pastel"` — pastel rotates through a curated set of soft pastel palettes (with high-contrast foreground), picking a new one at random for each session. Set it back to `"dark"` or `"light"` to disable the rotation. `resize_redraw_key` is used only by the PTY/status-bar path on terminal resize; accepted values are `ctrl-l`, `ctrl-shift-l` (same wire encoding as `ctrl-l`), or `disabled`. If unset, `codex` gets the `ctrl-shift-l` default and other commands stay off.
 
-When a boolean field is not set, the feature is enabled if the resource exists on the host. `no_save_config` is the exception: when unset, config auto-save is enabled in normal mode.
+When a boolean field is not set, the feature is in auto mode. For resource passthroughs, that means enabled if the resource exists on the host. For Git worktrees, that means enabled only when the current directory is a validated linked worktree. `no_save_config` is exception: when unset, config auto-save is enabled in normal mode.
 
 ## Windows
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ OPTIONS:
     --no-gpu / --gpu               Disable/enable GPU device passthrough (Linux only)
     --no-docker / --docker         Disable/enable Docker socket passthrough
     --no-display / --display       Disable/enable X11/Wayland passthrough (Linux only)
+    --worktree / --no-worktree     Enable/disable linked Git worktree metadata passthrough
     --no-mise / --mise             Disable/enable mise integration
     --ssh / --no-ssh               Share ~/.ssh read-only + forward SSH_AUTH_SOCK (default: off)
     --pictures / --no-pictures     Share ~/Pictures read-only (default: off)
@@ -58,6 +59,7 @@ pub struct CliArgs {
     pub gpu: Option<bool>,
     pub docker: Option<bool>,
     pub display: Option<bool>,
+    pub worktree: Option<bool>,
     pub mise: Option<bool>,
     pub save_config: Option<bool>,
     pub ssh: Option<bool>,
@@ -146,6 +148,8 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
             Long("no-docker") => args.docker = Some(false),
             Long("display") => args.display = Some(true),
             Long("no-display") => args.display = Some(false),
+            Long("worktree") => args.worktree = Some(true),
+            Long("no-worktree") => args.worktree = Some(false),
             Long("mise") => args.mise = Some(true),
             Long("no-mise") => args.mise = Some(false),
             Long("save-config") => args.save_config = Some(true),
@@ -363,6 +367,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_worktree() {
+        let args = parse_test(&["--worktree", "bash"]).unwrap();
+        assert_eq!(args.worktree, Some(true));
+    }
+
+    #[test]
+    fn parse_no_worktree() {
+        let args = parse_test(&["--no-worktree", "bash"]).unwrap();
+        assert_eq!(args.worktree, Some(false));
+    }
+
+    #[test]
     fn parse_mise() {
         let args = parse_test(&["--mise", "bash"]).unwrap();
         assert_eq!(args.mise, Some(true));
@@ -530,6 +546,7 @@ mod tests {
             "--verbose",
             "--no-gpu",
             "--no-docker",
+            "--worktree",
             "--rw-map",
             "/tmp/test",
             "claude",
@@ -539,6 +556,7 @@ mod tests {
         assert!(args.verbose);
         assert_eq!(args.gpu, Some(false));
         assert_eq!(args.docker, Some(false));
+        assert_eq!(args.worktree, Some(true));
         assert_eq!(args.rw_maps, vec![PathBuf::from("/tmp/test")]);
         assert_eq!(args.command, vec!["claude"]);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     #[serde(default)]
     pub no_display: Option<bool>,
     #[serde(default)]
+    pub no_worktree: Option<bool>,
+    #[serde(default)]
     pub no_mise: Option<bool>,
     #[serde(default)]
     pub no_save_config: Option<bool>,
@@ -63,6 +65,9 @@ impl Config {
     }
     pub fn mise_enabled(&self) -> bool {
         self.no_mise != Some(true)
+    }
+    pub fn worktree_enabled(&self) -> bool {
+        self.no_worktree != Some(true)
     }
     pub fn lockdown_enabled(&self) -> bool {
         self.lockdown == Some(true)
@@ -176,6 +181,9 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     }
     if local.no_mise.is_some() {
         c.no_mise = local.no_mise;
+    }
+    if local.no_worktree.is_some() {
+        c.no_worktree = local.no_worktree;
     }
     if local.no_save_config.is_some() {
         c.no_save_config = local.no_save_config;
@@ -371,6 +379,9 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     if let Some(v) = cli.pictures {
         config.pictures = Some(v);
     }
+    if let Some(v) = cli.worktree {
+        config.no_worktree = Some(!v);
+    }
     if let Some(v) = cli.lockdown {
         config.lockdown = Some(v);
     }
@@ -463,6 +474,7 @@ pub fn display_status(config: &Config) {
     bool_opt("GPU", config.no_gpu);
     bool_opt("Docker", config.no_docker);
     bool_opt("Display", config.no_display);
+    bool_opt("Git worktree", config.no_worktree);
     bool_opt("Mise", config.no_mise);
     match config.no_save_config {
         Some(true) => output::status_header("  Save config", "disabled"),
@@ -558,6 +570,7 @@ lockdown = true
         assert_eq!(cfg.no_gpu, Some(true));
         assert_eq!(cfg.no_docker, Some(false));
         assert_eq!(cfg.no_display, Some(true));
+        assert_eq!(cfg.no_worktree, None);
         assert_eq!(cfg.no_mise, Some(false));
         assert_eq!(cfg.no_save_config, Some(true));
         assert_eq!(cfg.lockdown, Some(true));
@@ -654,6 +667,7 @@ another_removed_field = true
         assert_eq!(cfg.no_gpu, None);
         assert_eq!(cfg.no_docker, None);
         assert_eq!(cfg.no_display, None);
+        assert_eq!(cfg.no_worktree, None);
         assert_eq!(cfg.no_mise, None);
         assert_eq!(cfg.no_save_config, None);
         assert_eq!(cfg.lockdown, None);
@@ -761,6 +775,30 @@ no_rlimits = false
     }
 
     #[test]
+    fn regression_v0_8_0_config_without_no_worktree() {
+        let toml = r#"
+command = ["claude"]
+rw_maps = []
+ro_maps = []
+hide_dotdirs = []
+no_gpu = false
+no_docker = false
+no_display = false
+no_mise = false
+lockdown = false
+no_landlock = false
+no_status_bar = false
+status_bar_style = "dark"
+no_seccomp = false
+no_rlimits = false
+allow_tcp_ports = []
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.no_worktree, None);
+        assert!(cfg.worktree_enabled());
+    }
+
+    #[test]
     fn regression_empty_config_file() {
         // An empty .ai-jail file must not crash
         let cfg = parse_toml("").unwrap();
@@ -787,6 +825,7 @@ no_rlimits = false
             no_gpu: Some(true),
             no_docker: None,
             no_display: Some(false),
+            no_worktree: Some(false),
             no_mise: None,
             no_save_config: Some(true),
             ssh: Some(true),
@@ -809,6 +848,7 @@ no_rlimits = false
         assert_eq!(deserialized.no_gpu, config.no_gpu);
         assert_eq!(deserialized.no_docker, config.no_docker);
         assert_eq!(deserialized.no_display, config.no_display);
+        assert_eq!(deserialized.no_worktree, config.no_worktree);
         assert_eq!(deserialized.no_mise, config.no_mise);
         assert_eq!(deserialized.no_save_config, config.no_save_config);
         assert_eq!(deserialized.lockdown, config.lockdown);
@@ -902,6 +942,17 @@ no_rlimits = false
     }
 
     #[test]
+    fn parse_config_with_no_worktree() {
+        let toml = r#"
+command = ["claude"]
+no_worktree = true
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.no_worktree, Some(true));
+        assert!(!cfg.worktree_enabled());
+    }
+
+    #[test]
     fn parse_hide_dotdirs() {
         let toml = r#"
 command = ["claude"]
@@ -944,6 +995,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
             no_gpu: Some(true),
             no_docker: Some(false),
             no_display: None,
+            no_worktree: Some(true),
             no_mise: Some(true),
             no_save_config: Some(true),
             lockdown: Some(true),
@@ -955,6 +1007,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
         assert_eq!(merged.no_gpu, Some(true));
         assert_eq!(merged.no_docker, Some(false));
         assert_eq!(merged.no_display, None);
+        assert_eq!(merged.no_worktree, Some(true));
         assert_eq!(merged.no_mise, Some(true));
         assert_eq!(merged.no_save_config, Some(true));
         assert_eq!(merged.lockdown, Some(true));
@@ -968,6 +1021,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
             gpu: Some(false),         // --no-gpu
             docker: Some(false),      // --no-docker
             display: Some(true),      // --display
+            worktree: Some(false),    // --no-worktree
             mise: Some(true),         // --mise
             save_config: Some(false), // --no-save-config
             lockdown: Some(true),     // --lockdown
@@ -977,6 +1031,7 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
         assert_eq!(merged.no_gpu, Some(true));
         assert_eq!(merged.no_docker, Some(true));
         assert_eq!(merged.no_display, Some(false));
+        assert_eq!(merged.no_worktree, Some(true));
         assert_eq!(merged.no_mise, Some(false));
         assert_eq!(merged.no_save_config, Some(true));
         assert_eq!(merged.lockdown, Some(true));
@@ -1004,6 +1059,28 @@ hide_dotdirs = [".my_secrets", ".proton", ".password-store"]
         };
         let merged = merge(&cli, existing);
         assert_eq!(merged.no_landlock, Some(true));
+    }
+
+    #[test]
+    fn merge_worktree_flag_overrides() {
+        let existing = Config {
+            no_worktree: None,
+            ..Config::default()
+        };
+
+        let cli = CliArgs {
+            worktree: Some(true),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing.clone());
+        assert_eq!(merged.no_worktree, Some(false));
+
+        let cli = CliArgs {
+            worktree: Some(false),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(merged.no_worktree, Some(true));
     }
 
     #[test]
@@ -1248,6 +1325,31 @@ allow_tcp_ports = [32000, 8080]
                 ..Config::default()
             }
             .display_enabled()
+        );
+    }
+
+    #[test]
+    fn worktree_enabled_accessor() {
+        assert!(
+            Config {
+                no_worktree: None,
+                ..Config::default()
+            }
+            .worktree_enabled()
+        );
+        assert!(
+            !Config {
+                no_worktree: Some(true),
+                ..Config::default()
+            }
+            .worktree_enabled()
+        );
+        assert!(
+            Config {
+                no_worktree: Some(false),
+                ..Config::default()
+            }
+            .worktree_enabled()
         );
     }
 
@@ -1506,6 +1608,7 @@ allow_tcp_ports = [32000, 8080]
             no_gpu: Some(true),
             no_docker: None,
             no_display: None,
+            no_worktree: None,
             no_mise: None,
             no_save_config: Some(true),
             ssh: None,

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -70,6 +70,7 @@ struct MountSet {
     config_hide: Vec<Mount>,
     cache_hide: Vec<Mount>,
     local_overrides: Vec<Mount>,
+    git_worktree: Vec<Mount>,
     gpu: Vec<Mount>,
     docker: Vec<Mount>,
     shm: Vec<Mount>,
@@ -84,7 +85,7 @@ struct MountSet {
 }
 
 impl MountSet {
-    fn ordered_mounts(&self) -> [&[Mount]; 15] {
+    fn ordered_mounts(&self) -> [&[Mount]; 16] {
         [
             &self.base,
             &self.sys_masks,
@@ -96,6 +97,7 @@ impl MountSet {
             &self.config_hide,
             &self.cache_hide,
             &self.local_overrides,
+            &self.git_worktree,
             &self.ssh_agent,
             &self.pictures,
             &self.extra,
@@ -578,6 +580,13 @@ fn landlock_wrapper_args(config: &Config, verbose: bool) -> Vec<String> {
     } else {
         "--no-display".into()
     });
+    if let Some(enabled) = config.no_worktree.map(|value| !value) {
+        args.push(if enabled {
+            "--worktree".into()
+        } else {
+            "--no-worktree".into()
+        });
+    }
     if config.ssh_enabled() {
         args.push("--ssh".into());
     }
@@ -910,6 +919,7 @@ fn discover_mounts(
         } else {
             discover_local_overrides()
         },
+        git_worktree: git_worktree_mounts(config, project_dir, verbose),
         gpu: if enable_gpu {
             discover_gpu(verbose)
         } else {
@@ -1314,6 +1324,37 @@ fn discover_display(verbose: bool) -> (Vec<Mount>, Vec<(String, String)>) {
     (mounts, env)
 }
 
+fn git_worktree_mounts(
+    config: &Config,
+    project_dir: &Path,
+    verbose: bool,
+) -> Vec<Mount> {
+    let Some(paths) =
+        super::discover_git_worktree_paths(config, project_dir, verbose)
+    else {
+        return vec![];
+    };
+
+    let readonly = config.lockdown_enabled();
+    paths
+        .unique_paths()
+        .into_iter()
+        .map(|path| {
+            if readonly {
+                Mount::RoBind {
+                    src: path.clone(),
+                    dest: path,
+                }
+            } else {
+                Mount::Bind {
+                    src: path.clone(),
+                    dest: path,
+                }
+            }
+        })
+        .collect()
+}
+
 fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
     let mut mounts = Vec::new();
 
@@ -1369,6 +1410,52 @@ fn project_mount(project_dir: &Path, readonly: bool) -> Vec<Mount> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct LinkedWorktreeFixture {
+        root: PathBuf,
+        project_dir: PathBuf,
+        git_dir: PathBuf,
+        common_dir: PathBuf,
+    }
+
+    impl Drop for LinkedWorktreeFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn create_linked_worktree_fixture() -> LinkedWorktreeFixture {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-bwrap-worktree-{}-{nonce}",
+            std::process::id()
+        ));
+        let project_dir = root.join("project");
+        let common_dir = root.join("common/.git");
+        let git_dir = common_dir.join("worktrees/wt1");
+
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(
+            project_dir.join(".git"),
+            "gitdir: ../common/.git/worktrees/wt1\n",
+        )
+        .unwrap();
+        std::fs::write(git_dir.join("gitdir"), "../../../../project/.git\n")
+            .unwrap();
+        std::fs::write(git_dir.join("commondir"), "../..\n").unwrap();
+
+        LinkedWorktreeFixture {
+            root,
+            project_dir,
+            git_dir,
+            common_dir,
+        }
+    }
 
     // Tests that mutate process-global env vars must hold this lock.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -1656,6 +1743,141 @@ mod tests {
             .windows(3)
             .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
         assert!(!has_tmp_bind);
+    }
+
+    #[test]
+    fn linked_worktree_paths_are_rw_in_normal_mode() {
+        let fixture = create_linked_worktree_fixture();
+        let config = minimal_test_config();
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &fixture.project_dir,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(args.windows(3).any(|w| {
+            w[0] == "--bind"
+                && super::super::paths_equivalent(
+                    Path::new(&w[1]),
+                    &fixture.git_dir,
+                )
+                && super::super::paths_equivalent(
+                    Path::new(&w[2]),
+                    &fixture.git_dir,
+                )
+        }));
+        assert!(args.windows(3).any(|w| {
+            w[0] == "--bind"
+                && super::super::paths_equivalent(
+                    Path::new(&w[1]),
+                    &fixture.common_dir,
+                )
+                && super::super::paths_equivalent(
+                    Path::new(&w[2]),
+                    &fixture.common_dir,
+                )
+        }));
+    }
+
+    #[test]
+    fn linked_worktree_paths_are_ro_in_lockdown() {
+        let fixture = create_linked_worktree_fixture();
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &fixture.project_dir,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(args.windows(3).any(|w| {
+            w[0] == "--ro-bind"
+                && super::super::paths_equivalent(
+                    Path::new(&w[1]),
+                    &fixture.git_dir,
+                )
+                && super::super::paths_equivalent(
+                    Path::new(&w[2]),
+                    &fixture.git_dir,
+                )
+        }));
+        assert!(args.windows(3).any(|w| {
+            w[0] == "--ro-bind"
+                && super::super::paths_equivalent(
+                    Path::new(&w[1]),
+                    &fixture.common_dir,
+                )
+                && super::super::paths_equivalent(
+                    Path::new(&w[2]),
+                    &fixture.common_dir,
+                )
+        }));
+    }
+
+    #[test]
+    fn invalid_linked_worktree_layout_is_ignored() {
+        let fixture = create_linked_worktree_fixture();
+        std::fs::remove_file(fixture.git_dir.join("commondir")).unwrap();
+        let config = minimal_test_config();
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &fixture.project_dir,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(!args.iter().any(|arg| {
+            super::super::paths_equivalent(Path::new(arg), &fixture.git_dir)
+        }));
+        assert!(!args.iter().any(|arg| {
+            super::super::paths_equivalent(Path::new(arg), &fixture.common_dir)
+        }));
+    }
+
+    #[test]
+    fn disabled_worktree_passthrough_skips_mounts() {
+        let fixture = create_linked_worktree_fixture();
+        let mut config = minimal_test_config();
+        config.no_worktree = Some(true);
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &fixture.project_dir,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(!args.iter().any(|arg| {
+            super::super::paths_equivalent(Path::new(arg), &fixture.git_dir)
+        }));
+        assert!(!args.iter().any(|arg| {
+            super::super::paths_equivalent(Path::new(arg), &fixture.common_dir)
+        }));
     }
 
     #[test]

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -144,7 +144,7 @@ fn do_apply(
     let access_read = AccessFs::from_read(ABI_VERSION);
 
     let (ro_paths, rw_paths) = if config.lockdown_enabled() {
-        collect_lockdown_paths(project_dir, verbose)
+        collect_lockdown_paths(config, project_dir, verbose)
     } else {
         collect_normal_paths(config, project_dir, verbose)
     };
@@ -277,6 +277,7 @@ fn apply_net_rules(config: &Config, verbose: bool) -> Result<(), String> {
 /// from writing anywhere except /tmp, so it cannot persist
 /// backdoors, modify configs, or exfiltrate data to disk.
 fn collect_lockdown_paths(
+    config: &Config,
     project_dir: &Path,
     verbose: bool,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
@@ -326,6 +327,20 @@ fn collect_lockdown_paths(
             "Landlock lockdown: {} ro",
             project_dir.display()
         ));
+    }
+
+    if let Some(paths) =
+        super::discover_git_worktree_paths(config, project_dir, verbose)
+    {
+        for path in paths.unique_paths() {
+            if verbose {
+                output::verbose(&format!(
+                    "Landlock lockdown: git worktree {} ro",
+                    path.display()
+                ));
+            }
+            ro.push(path);
+        }
     }
 
     (ro, rw)
@@ -483,6 +498,20 @@ fn collect_normal_paths(
             output::verbose("Landlock: ~/.gitconfig ro");
         }
         ro.push(gitconfig);
+    }
+
+    if let Some(paths) =
+        super::discover_git_worktree_paths(config, project_dir, verbose)
+    {
+        for path in paths.unique_paths() {
+            if verbose {
+                output::verbose(&format!(
+                    "Landlock: git worktree {} rw",
+                    path.display()
+                ));
+            }
+            rw.push(path);
+        }
     }
 
     // Extra user mounts: --rw-map and --ro-map from CLI/config.
@@ -655,6 +684,52 @@ fn collect_gpu_paths(rw: &mut Vec<PathBuf>, verbose: bool) {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct LinkedWorktreeFixture {
+        root: PathBuf,
+        project_dir: PathBuf,
+        git_dir: PathBuf,
+        common_dir: PathBuf,
+    }
+
+    impl Drop for LinkedWorktreeFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn create_linked_worktree_fixture() -> LinkedWorktreeFixture {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-landlock-worktree-{}-{nonce}",
+            std::process::id()
+        ));
+        let project_dir = root.join("project");
+        let common_dir = root.join("common/.git");
+        let git_dir = common_dir.join("worktrees/wt1");
+
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(
+            project_dir.join(".git"),
+            "gitdir: ../common/.git/worktrees/wt1\n",
+        )
+        .unwrap();
+        std::fs::write(git_dir.join("gitdir"), "../../../../project/.git\n")
+            .unwrap();
+        std::fs::write(git_dir.join("commondir"), "../..\n").unwrap();
+
+        LinkedWorktreeFixture {
+            root,
+            project_dir,
+            git_dir,
+            common_dir,
+        }
+    }
 
     // Tests mutating process-global env vars must hold this lock.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -701,20 +776,29 @@ mod tests {
     #[test]
     fn lockdown_paths_project_is_readonly() {
         let project = PathBuf::from("/home/user/project");
-        let (ro, rw) = collect_lockdown_paths(&project, false);
+        let (ro, rw) =
+            collect_lockdown_paths(&Config::default(), &project, false);
         assert!(ro.contains(&project), "project must be in ro list");
         assert!(!rw.contains(&project), "project must not be in rw list");
     }
 
     #[test]
     fn lockdown_paths_tmp_is_writable() {
-        let (_, rw) = collect_lockdown_paths(Path::new("/tmp/proj"), false);
+        let (_, rw) = collect_lockdown_paths(
+            &Config::default(),
+            Path::new("/tmp/proj"),
+            false,
+        );
         assert!(rw.contains(&PathBuf::from("/tmp")));
     }
 
     #[test]
     fn lockdown_paths_dev_is_writable() {
-        let (ro, rw) = collect_lockdown_paths(Path::new("/tmp/proj"), false);
+        let (ro, rw) = collect_lockdown_paths(
+            &Config::default(),
+            Path::new("/tmp/proj"),
+            false,
+        );
         assert!(rw.contains(&PathBuf::from("/dev")));
         assert!(!ro.contains(&PathBuf::from("/dev")));
     }
@@ -747,7 +831,11 @@ mod tests {
 
     #[test]
     fn lockdown_paths_root_is_readable() {
-        let (ro, _) = collect_lockdown_paths(Path::new("/tmp/proj"), false);
+        let (ro, _) = collect_lockdown_paths(
+            &Config::default(),
+            Path::new("/tmp/proj"),
+            false,
+        );
         assert!(
             ro.contains(&PathBuf::from("/")),
             "/ must be in ro list so bwrap can set up mount namespaces"
@@ -876,5 +964,68 @@ mod tests {
         // Empty ports → same as no ports → best-effort V4 or
         // fallback to --unshare-net only.
         let _ = apply_net_rules(&config, true);
+    }
+
+    #[test]
+    fn normal_paths_include_linked_worktree_git_dirs() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            ..Config::default()
+        };
+
+        let (_, rw) =
+            collect_normal_paths(&config, &fixture.project_dir, false);
+        assert!(rw.iter().any(|path| super::super::paths_equivalent(
+            path,
+            &fixture.git_dir
+        )));
+        assert!(rw.iter().any(|path| {
+            super::super::paths_equivalent(path, &fixture.common_dir)
+        }));
+    }
+
+    #[test]
+    fn lockdown_paths_include_linked_worktree_git_dirs_read_only() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            lockdown: Some(true),
+            ..Config::default()
+        };
+
+        let (ro, rw) =
+            collect_lockdown_paths(&config, &fixture.project_dir, false);
+        assert!(ro.iter().any(|path| super::super::paths_equivalent(
+            path,
+            &fixture.git_dir
+        )));
+        assert!(ro.iter().any(|path| {
+            super::super::paths_equivalent(path, &fixture.common_dir)
+        }));
+        assert!(!rw.iter().any(|path| super::super::paths_equivalent(
+            path,
+            &fixture.git_dir
+        )));
+    }
+
+    #[test]
+    fn disabled_worktree_passthrough_skips_landlock_paths() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            no_worktree: Some(true),
+            ..Config::default()
+        };
+
+        let (_, rw) =
+            collect_normal_paths(&config, &fixture.project_dir, false);
+        assert!(!rw.iter().any(|path| super::super::paths_equivalent(
+            path,
+            &fixture.git_dir
+        )));
+        assert!(!rw.iter().any(|path| super::super::paths_equivalent(
+            path,
+            &fixture.common_dir
+        )));
     }
 }

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -149,6 +149,154 @@ fn path_exists(p: &Path) -> bool {
     p.exists() || p.symlink_metadata().is_ok()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitWorktreePaths {
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+}
+
+impl GitWorktreePaths {
+    pub(crate) fn unique_paths(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = Vec::new();
+        for path in [self.git_dir.clone(), self.common_dir.clone()] {
+            if !paths
+                .iter()
+                .any(|existing| paths_equivalent(existing, &path))
+            {
+                paths.push(path);
+            }
+        }
+        paths
+    }
+}
+
+pub(crate) fn discover_git_worktree_paths(
+    config: &Config,
+    project_dir: &Path,
+    verbose: bool,
+) -> Option<GitWorktreePaths> {
+    if !config.worktree_enabled() {
+        if verbose {
+            crate::output::verbose("Git worktree: disabled");
+        }
+        return None;
+    }
+
+    match validate_linked_git_worktree(project_dir) {
+        Ok(Some(paths)) => {
+            if verbose {
+                crate::output::verbose(&format!(
+                    "Git worktree: exposing {}",
+                    paths
+                        .unique_paths()
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            Some(paths)
+        }
+        Ok(None) => {
+            if verbose {
+                crate::output::verbose(
+                    "Git worktree: not a linked worktree root",
+                );
+            }
+            None
+        }
+        Err(reason) => {
+            if verbose {
+                crate::output::verbose(&format!(
+                    "Git worktree: skipped ({reason})"
+                ));
+            }
+            None
+        }
+    }
+}
+
+fn validate_linked_git_worktree(
+    project_dir: &Path,
+) -> Result<Option<GitWorktreePaths>, String> {
+    let project_git = project_dir.join(".git");
+    if project_git.is_dir() {
+        return Ok(None);
+    }
+    if !project_git.is_file() {
+        return Ok(None);
+    }
+
+    let git_dir = parse_gitfile_target(&project_git)?;
+    if !git_dir.is_dir() {
+        return Err(format!(
+            "gitdir target {} is not a directory",
+            git_dir.display()
+        ));
+    }
+
+    let reverse_gitdir = read_resolved_path_file(&git_dir.join("gitdir"))?;
+    if !paths_equivalent(&reverse_gitdir, &project_git) {
+        return Err(format!(
+            "{} does not point back to {}",
+            git_dir.join("gitdir").display(),
+            project_git.display()
+        ));
+    }
+
+    let common_dir = read_resolved_path_file(&git_dir.join("commondir"))?;
+    if !common_dir.is_dir() {
+        return Err(format!(
+            "commondir target {} is not a directory",
+            common_dir.display()
+        ));
+    }
+
+    Ok(Some(GitWorktreePaths {
+        git_dir,
+        common_dir,
+    }))
+}
+
+fn parse_gitfile_target(gitfile: &Path) -> Result<PathBuf, String> {
+    let contents = std::fs::read_to_string(gitfile)
+        .map_err(|e| format!("cannot read {}: {e}", gitfile.display()))?;
+    let line = contents.trim();
+    let raw = line
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            format!("{} is not a valid gitfile", gitfile.display())
+        })?;
+    Ok(resolve_path_from_file(gitfile, Path::new(raw)))
+}
+
+fn read_resolved_path_file(path: &Path) -> Result<PathBuf, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let raw = contents.trim();
+    if raw.is_empty() {
+        return Err(format!("{} is empty", path.display()));
+    }
+    Ok(resolve_path_from_file(path, Path::new(raw)))
+}
+
+fn resolve_path_from_file(file: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        file.parent().unwrap_or_else(|| Path::new(".")).join(path)
+    }
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => left == right,
+    }
+}
+
 fn mise_bin() -> Option<PathBuf> {
     std::env::var("PATH").ok().and_then(|paths| {
         paths.split(':').find_map(|dir| {
@@ -309,6 +457,55 @@ pub fn dry_run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct LinkedWorktreeFixture {
+        root: PathBuf,
+        project_dir: PathBuf,
+        git_dir: PathBuf,
+        common_dir: PathBuf,
+    }
+
+    impl Drop for LinkedWorktreeFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn temp_test_dir(prefix: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir()
+            .join(format!("ai-jail-{prefix}-{}-{nonce}", std::process::id()))
+    }
+
+    fn create_linked_worktree_fixture() -> LinkedWorktreeFixture {
+        let root = temp_test_dir("worktree");
+        let project_dir = root.join("project");
+        let common_dir = root.join("common/.git");
+        let git_dir = common_dir.join("worktrees/wt1");
+
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        std::fs::write(
+            project_dir.join(".git"),
+            "gitdir: ../common/.git/worktrees/wt1\n",
+        )
+        .unwrap();
+        std::fs::write(git_dir.join("gitdir"), "../../../../project/.git\n")
+            .unwrap();
+        std::fs::write(git_dir.join("commondir"), "../..\n").unwrap();
+
+        LinkedWorktreeFixture {
+            root,
+            project_dir,
+            git_dir,
+            common_dir,
+        }
+    }
 
     #[test]
     fn default_launch_is_bash() {
@@ -497,5 +694,75 @@ mod tests {
         assert!(denied.contains(&"aws".to_string()));
         assert!(denied.contains(&"my_secrets".to_string()));
         assert!(denied.contains(&"proton".to_string()));
+    }
+
+    #[test]
+    fn validate_linked_git_worktree_skips_normal_repo_root() {
+        let root = temp_test_dir("normal-repo");
+        let project_dir = root.join("project");
+        std::fs::create_dir_all(project_dir.join(".git")).unwrap();
+
+        assert!(
+            validate_linked_git_worktree(&project_dir)
+                .unwrap()
+                .is_none()
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn validate_linked_git_worktree_discovers_valid_layout() {
+        let fixture = create_linked_worktree_fixture();
+
+        let paths = validate_linked_git_worktree(&fixture.project_dir)
+            .unwrap()
+            .unwrap();
+
+        assert!(paths_equivalent(&paths.git_dir, &fixture.git_dir));
+        assert!(paths_equivalent(&paths.common_dir, &fixture.common_dir));
+        assert_eq!(paths.unique_paths().len(), 2);
+    }
+
+    #[test]
+    fn validate_linked_git_worktree_rejects_malformed_gitfile() {
+        let root = temp_test_dir("bad-gitfile");
+        let project_dir = root.join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join(".git"), "definitely not a gitfile\n")
+            .unwrap();
+
+        let err = validate_linked_git_worktree(&project_dir).unwrap_err();
+        assert!(err.contains("valid gitfile"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn validate_linked_git_worktree_rejects_mismatched_reverse_link() {
+        let fixture = create_linked_worktree_fixture();
+        std::fs::write(
+            fixture.git_dir.join("gitdir"),
+            "../../../../other/.git\n",
+        )
+        .unwrap();
+
+        let err =
+            validate_linked_git_worktree(&fixture.project_dir).unwrap_err();
+        assert!(err.contains("does not point back"));
+    }
+
+    #[test]
+    fn discover_git_worktree_paths_respects_disabled_config() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            no_worktree: Some(true),
+            ..Config::default()
+        };
+
+        assert!(
+            discover_git_worktree_paths(&config, &fixture.project_dir, false)
+                .is_none()
+        );
     }
 }

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -195,7 +195,7 @@ fn generate_sbpl_profile(
 
     if lockdown {
         profile.push_str("; File reads: lockdown allow-list\n");
-        for rd_path in macos_lockdown_read_paths(project_dir) {
+        for rd_path in macos_lockdown_read_paths(config, project_dir) {
             let canonical = canonicalize_or_keep(&rd_path);
             let escaped = sbpl_escape(canonical.to_string_lossy().as_ref());
             if canonical.is_dir() || !canonical.exists() {
@@ -337,6 +337,12 @@ fn macos_writable_paths(
 
     paths.push(project_dir.to_path_buf());
 
+    if let Some(worktree) =
+        super::discover_git_worktree_paths(config, project_dir, false)
+    {
+        paths.extend(worktree.unique_paths());
+    }
+
     for name in super::DOTDIR_RW {
         let p = home.join(name);
         if super::path_exists(&p) {
@@ -391,7 +397,10 @@ fn macos_docker_socket() -> Option<PathBuf> {
     candidates.into_iter().find(|p| super::path_exists(p))
 }
 
-fn macos_lockdown_read_paths(project_dir: &Path) -> Vec<PathBuf> {
+fn macos_lockdown_read_paths(
+    config: &Config,
+    project_dir: &Path,
+) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let mut push_unique = |p: PathBuf| {
         if !paths.contains(&p) {
@@ -401,6 +410,14 @@ fn macos_lockdown_read_paths(project_dir: &Path) -> Vec<PathBuf> {
 
     // Always allow reading the project tree.
     push_unique(canonicalize_or_keep(project_dir));
+
+    if let Some(worktree) =
+        super::discover_git_worktree_paths(config, project_dir, false)
+    {
+        for path in worktree.unique_paths() {
+            push_unique(canonicalize_or_keep(&path));
+        }
+    }
 
     // Core runtime and toolchain locations needed to execute binaries
     // and resolve dynamic libraries on macOS.
@@ -439,6 +456,52 @@ fn macos_lockdown_read_paths(project_dir: &Path) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct LinkedWorktreeFixture {
+        root: PathBuf,
+        project_dir: PathBuf,
+        git_dir: PathBuf,
+        common_dir: PathBuf,
+    }
+
+    impl Drop for LinkedWorktreeFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn create_linked_worktree_fixture() -> LinkedWorktreeFixture {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-seatbelt-worktree-{}-{nonce}",
+            std::process::id()
+        ));
+        let project_dir = root.join("project");
+        let common_dir = root.join("common/.git");
+        let git_dir = common_dir.join("worktrees/wt1");
+
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(
+            project_dir.join(".git"),
+            "gitdir: ../common/.git/worktrees/wt1\n",
+        )
+        .unwrap();
+        std::fs::write(git_dir.join("gitdir"), "../../../../project/.git\n")
+            .unwrap();
+        std::fs::write(git_dir.join("commondir"), "../..\n").unwrap();
+
+        LinkedWorktreeFixture {
+            root,
+            project_dir,
+            git_dir,
+            common_dir,
+        }
+    }
 
     #[test]
     fn sbpl_profile_has_deny_default() {
@@ -519,7 +582,39 @@ mod tests {
     #[test]
     fn lockdown_read_paths_include_project() {
         let project = PathBuf::from("/tmp/test-project");
-        let paths = macos_lockdown_read_paths(&project);
+        let paths = macos_lockdown_read_paths(&Config::default(), &project);
         assert!(paths.contains(&project));
+    }
+
+    #[test]
+    fn writable_paths_include_linked_worktree_git_dirs() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            no_mise: Some(true),
+            ..Config::default()
+        };
+        let paths = macos_writable_paths(&fixture.project_dir, &config, false);
+        assert!(paths.iter().any(|path| path == &fixture.git_dir));
+        assert!(paths.iter().any(|path| path == &fixture.common_dir));
+    }
+
+    #[test]
+    fn lockdown_read_paths_include_linked_worktree_git_dirs() {
+        let fixture = create_linked_worktree_fixture();
+        let config = Config {
+            lockdown: Some(true),
+            ..Config::default()
+        };
+        let paths = macos_lockdown_read_paths(&config, &fixture.project_dir);
+        assert!(
+            paths
+                .iter()
+                .any(|path| path == &canonicalize_or_keep(&fixture.git_dir))
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|path| path == &canonicalize_or_keep(&fixture.common_dir))
+        );
     }
 }


### PR DESCRIPTION
If I try to use ai-jail in a git worktree, all the git commands fail because the root worktree is not accessible in the ai-jail.

Example:

```shell
$ ai-jail --no-worktree bash
$ git status
fatal: not a git repository: ~/workspace/ai-jail/.git/worktrees/test-worktree
```

```
$ ai-jail --worktree bash
$ git status
On branch test-worktree
nothing to commit, working tree clean
```

I have been using this for a couple of days, and it's working well.