### PR TITLE
feat: add --claude-dir flag for custom Claude config directories

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -131,11 +131,11 @@ const ASK: &[&str] = &[
 
 // ── Public entry point ───────────────────────────────────────────
 
-pub fn run(verbose: bool) -> Result<(), String> {
+pub fn run(verbose: bool, claude_dir: Option<&Path>) -> Result<(), String> {
     output::info("Bootstrapping AI tool configs...");
 
     bootstrap_gemini(verbose)?;
-    bootstrap_claude(verbose)?;
+    bootstrap_claude(verbose, claude_dir)?;
     bootstrap_codex(verbose)?;
     bootstrap_opencode(verbose)?;
     bootstrap_crush(verbose)?;
@@ -365,9 +365,14 @@ fn bootstrap_gemini(verbose: bool) -> Result<(), String> {
 
 // ── Claude ───────────────────────────────────────────────────────
 
-fn claude_config_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    PathBuf::from(home).join(".claude").join("settings.json")
+fn claude_config_path(claude_dir: Option<&Path>) -> PathBuf {
+    match claude_dir {
+        Some(dir) => dir.join("settings.json"),
+        None => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+            PathBuf::from(home).join(".claude").join("settings.json")
+        }
+    }
 }
 
 fn build_claude_permissions() -> serde_json::Value {
@@ -392,8 +397,11 @@ fn build_claude_permissions() -> serde_json::Value {
     })
 }
 
-fn bootstrap_claude(verbose: bool) -> Result<(), String> {
-    let path = claude_config_path();
+fn bootstrap_claude(
+    verbose: bool,
+    claude_dir: Option<&Path>,
+) -> Result<(), String> {
+    let path = claude_config_path(claude_dir);
     ensure_regular_file_or_absent(&path)?;
 
     let mut root = if path.exists() {
@@ -608,6 +616,7 @@ mod tests {
 
     use std::sync::atomic::{AtomicU32, Ordering};
     static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn test_dir() -> PathBuf {
         let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -939,5 +948,26 @@ sandbox_mode = "full"
         assert!(result.contains_key("mcpServers"));
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ── claude_config_path with custom dir ─────────────────────
+
+    #[test]
+    fn claude_config_path_uses_custom_dir() {
+        let custom = PathBuf::from("/home/user/.claude-example");
+        let path = claude_config_path(Some(&custom));
+        assert_eq!(
+            path,
+            PathBuf::from("/home/user/.claude-example/settings.json")
+        );
+    }
+
+    #[test]
+    fn claude_config_path_defaults_to_dot_claude() {
+        let _env = ENV_LOCK.lock().unwrap();
+        unsafe { env::set_var("HOME", "/home/testuser") };
+        let path = claude_config_path(None);
+        assert_eq!(path, PathBuf::from("/home/testuser/.claude/settings.json"));
+        unsafe { env::remove_var("HOME") };
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,7 @@ OPTIONS:
     --no-status-bar                Disable persistent status line
     --exec                         Direct execution mode (no PTY proxy, no status bar)
     --allow-tcp-port <PORT>        Allow outbound TCP to PORT in lockdown (repeatable)
+    --claude-dir <PATH>            Use PATH as Claude config dir (sets CLAUDE_CONFIG_DIR)
     --clean                        Ignore existing .ai-jail config, start fresh
     --dry-run                      Print the sandbox command without executing
     --init                         Create/update .ai-jail config and exit
@@ -73,6 +74,7 @@ pub struct CliArgs {
     pub status_bar: Option<bool>,
     pub status_bar_style: Option<String>,
     pub allow_tcp_ports: Vec<u16>,
+    pub claude_dir: Option<PathBuf>,
     pub exec: bool,
     pub clean: bool,
     pub dry_run: bool,
@@ -149,6 +151,11 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
                     .parse()
                     .map_err(|_| format!("invalid port number: {val}"))?;
                 args.allow_tcp_ports.push(port);
+            }
+            Long("claude-dir") => {
+                let val = parser.value().map_err(|e| e.to_string())?;
+                args.claude_dir =
+                    Some(PathBuf::from(val.to_string_lossy().into_owned()));
             }
             Long("gpu") => args.gpu = Some(true),
             Long("no-gpu") => args.gpu = Some(false),
@@ -836,6 +843,26 @@ mod tests {
     #[test]
     fn parse_allow_tcp_port_missing_value() {
         assert!(parse_test(&["--allow-tcp-port"]).is_err());
+    }
+
+    #[test]
+    fn parse_claude_dir() {
+        let args = parse_test(&[
+            "--claude-dir",
+            "/home/user/.claude-example",
+            "claude",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.claude_dir,
+            Some(PathBuf::from("/home/user/.claude-example"))
+        );
+        assert_eq!(args.command, vec!["claude"]);
+    }
+
+    #[test]
+    fn parse_claude_dir_missing_value_errors() {
+        assert!(parse_test(&["--claude-dir"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,8 @@ pub struct Config {
     pub no_rlimits: Option<bool>,
     #[serde(default)]
     pub allow_tcp_ports: Vec<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_dir: Option<PathBuf>,
 }
 
 impl Config {
@@ -256,6 +258,9 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     c.allow_tcp_ports.extend(local.allow_tcp_ports);
     c.allow_tcp_ports.sort_unstable();
     c.allow_tcp_ports.dedup();
+    if local.claude_dir.is_some() {
+        c.claude_dir = local.claude_dir;
+    }
     // Status bar + resize redraw key stay from global — local should
     // not override user-level preferences.
     c
@@ -493,6 +498,13 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     config.allow_tcp_ports.sort_unstable();
     config.allow_tcp_ports.dedup();
 
+    if let Some(p) = cli.claude_dir.clone() {
+        config.claude_dir = Some(p);
+    }
+    if let Some(p) = config.claude_dir.take() {
+        config.claude_dir = Some(expand_tilde(p));
+    }
+
     // Expand ~ / ~/ in all user-provided path fields. Config
     // files are TOML (no shell expansion); CLI args are shell-
     // expanded already but harmless to re-run. Only leading
@@ -625,6 +637,9 @@ pub fn display_status(config: &Config) {
     }
     if let Some(key) = config.resize_redraw_key.as_deref() {
         output::status_header("  Resize redraw", key);
+    }
+    if let Some(dir) = &config.claude_dir {
+        output::status_header("  Claude dir", &dir.display().to_string());
     }
 }
 
@@ -791,6 +806,7 @@ another_removed_field = true
         assert_eq!(cfg.no_seccomp, None);
         assert_eq!(cfg.no_rlimits, None);
         assert!(cfg.allow_tcp_ports.is_empty());
+        assert_eq!(cfg.claude_dir, None);
     }
 
     #[test]
@@ -983,6 +999,7 @@ allow_tcp_ports = []
             no_seccomp: None,
             no_rlimits: None,
             allow_tcp_ports: vec![32000, 8080],
+            claude_dir: None,
         };
         let serialized = serialize_config(&config).unwrap();
         let deserialized = parse_toml(&serialized).unwrap();
@@ -1004,6 +1021,7 @@ allow_tcp_ports = []
         assert_eq!(deserialized.no_seccomp, config.no_seccomp);
         assert_eq!(deserialized.no_rlimits, config.no_rlimits);
         assert_eq!(deserialized.allow_tcp_ports, config.allow_tcp_ports);
+        assert_eq!(deserialized.claude_dir, config.claude_dir);
     }
 
     // ── Merge tests ────────────────────────────────────────────
@@ -1826,6 +1844,7 @@ allow_tcp_ports = [32000, 8080]
             no_seccomp: None,
             no_rlimits: None,
             allow_tcp_ports: vec![32000],
+            claude_dir: None,
         };
         save(&config);
 
@@ -1837,6 +1856,7 @@ allow_tcp_ports = [32000, 8080]
         assert_eq!(loaded.allow_tcp_ports, vec![32000]);
         assert_eq!(loaded.resize_redraw_key, None);
         assert_eq!(loaded.browser_profile.as_deref(), Some("hard"));
+        assert_eq!(loaded.claude_dir, None);
 
         // Cleanup
         std::env::set_current_dir(&original_dir).unwrap();
@@ -1960,5 +1980,127 @@ allow_tcp_ports = [32000, 8080]
                 std::env::set_var("HOME", v);
             }
         }
+    }
+
+    // ── claude_dir tests ──────────────────────────────────────
+
+    #[test]
+    fn regression_v0_9_0_config_without_claude_dir() {
+        let toml = r#"
+command = ["claude"]
+rw_maps = []
+ro_maps = []
+no_gpu = false
+no_docker = false
+lockdown = false
+no_landlock = false
+no_status_bar = false
+no_seccomp = false
+no_rlimits = false
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.claude_dir, None);
+    }
+
+    #[test]
+    fn parse_claude_dir_from_toml() {
+        let toml = r#"
+command = ["claude"]
+claude_dir = "/home/user/.claude-example"
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(
+            cfg.claude_dir,
+            Some(PathBuf::from("/home/user/.claude-example"))
+        );
+    }
+
+    #[test]
+    fn merge_claude_dir_from_cli() {
+        let existing = Config::default();
+        let cli = CliArgs {
+            claude_dir: Some(PathBuf::from("/home/user/.claude-example")),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(
+            merged.claude_dir,
+            Some(PathBuf::from("/home/user/.claude-example"))
+        );
+    }
+
+    #[test]
+    fn merge_claude_dir_expands_tilde() {
+        let _env = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("HOME", "/home/testuser") };
+
+        let existing = Config::default();
+        let cli = CliArgs {
+            claude_dir: Some(PathBuf::from("~/.claude-example")),
+            ..CliArgs::default()
+        };
+        let merged = merge(&cli, existing);
+        assert_eq!(
+            merged.claude_dir,
+            Some(PathBuf::from("/home/testuser/.claude-example"))
+        );
+
+        unsafe { std::env::remove_var("HOME") };
+    }
+
+    #[test]
+    fn merge_cli_no_claude_dir_preserves_config_claude_dir() {
+        let existing = Config {
+            claude_dir: Some(PathBuf::from("/home/user/.claude-example")),
+            ..Config::default()
+        };
+        let cli = CliArgs::default();
+        let merged = merge(&cli, existing);
+        assert_eq!(
+            merged.claude_dir,
+            Some(PathBuf::from("/home/user/.claude-example"))
+        );
+    }
+
+    #[test]
+    fn merge_expands_tilde_from_config_file() {
+        let _env = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("HOME", "/home/testuser") };
+
+        let existing = Config {
+            claude_dir: Some(PathBuf::from("~/.claude-example")),
+            ..Config::default()
+        };
+        let cli = CliArgs::default();
+        let merged = merge(&cli, existing);
+        assert_eq!(
+            merged.claude_dir,
+            Some(PathBuf::from("/home/testuser/.claude-example"))
+        );
+
+        unsafe { std::env::remove_var("HOME") };
+    }
+
+    #[test]
+    fn roundtrip_claude_dir() {
+        let config = Config {
+            command: vec!["claude".into()],
+            claude_dir: Some(PathBuf::from("/home/user/.claude-example")),
+            ..Config::default()
+        };
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized = parse_toml(&serialized).unwrap();
+        assert_eq!(deserialized.claude_dir, config.claude_dir);
+    }
+
+    #[test]
+    fn roundtrip_claude_dir_none_not_written() {
+        let config = Config {
+            command: vec!["claude".into()],
+            claude_dir: None,
+            ..Config::default()
+        };
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(!serialized.contains("claude_dir"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn run() -> Result<i32, String> {
 
     // Handle --bootstrap: generate AI tool configs and exit
     if cli.bootstrap {
-        bootstrap::run(cli.verbose)?;
+        bootstrap::run(cli.verbose, config.claude_dir.as_deref())?;
         return Ok(0);
     }
 

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -78,6 +78,7 @@ struct MountSet {
     display_env: Vec<(String, String)>,
     ssh_agent: Vec<Mount>,
     ssh_env: Vec<(String, String)>,
+    claude_env: Vec<(String, String)>,
     pictures: Vec<Mount>,
     browser_state: Vec<Mount>,
     extra: Vec<Mount>,
@@ -181,6 +182,13 @@ impl MountSet {
                 args.push(key.clone());
                 args.push(val.clone());
             }
+        }
+
+        // Claude config dir env (always, even in lockdown)
+        for (key, val) in &self.claude_env {
+            args.push("--setenv".into());
+            args.push(key.clone());
+            args.push(val.clone());
         }
 
         args.extend([
@@ -621,6 +629,10 @@ fn landlock_wrapper_args(config: &Config, verbose: bool) -> Vec<String> {
         args.push("--mask".into());
         args.push(path.display().to_string());
     }
+    if let Some(dir) = &config.claude_dir {
+        args.push("--claude-dir".into());
+        args.push(dir.display().to_string());
+    }
 
     if verbose {
         args.push("--verbose".into());
@@ -896,6 +908,14 @@ fn discover_mounts(
             (vec![], vec![])
         };
 
+    // Claude config dir env var
+    let claude_env: Vec<(String, String)> =
+        if let Some(dir) = &config.claude_dir {
+            vec![("CLAUDE_CONFIG_DIR".into(), dir.display().to_string())]
+        } else {
+            vec![]
+        };
+
     // Mask: replace each path with an empty tempfile (or tmpfs
     // for directories). Paths are resolved absolutely; relative
     // paths resolve against project_dir.
@@ -921,15 +941,29 @@ fn discover_mounts(
     let browser_state_mount =
         discover_browser_state_mount(config, browser_profile, verbose);
 
+    let mut home_dotfiles = discover_home_dotfiles(
+        private_home,
+        &config.hide_dotdirs,
+        &exempt,
+        verbose,
+    );
+    if !lockdown
+        && let Some(dir) = &config.claude_dir
+        && super::path_exists(dir)
+    {
+        if verbose {
+            output::verbose(&format!("claude-dir: {}", dir.display()));
+        }
+        home_dotfiles.push(Mount::Bind {
+            src: dir.clone(),
+            dest: dir.clone(),
+        });
+    }
+
     MountSet {
         base: discover_base(hosts_file, resolv_mount),
         sys_masks: discover_sys_masks(lockdown),
-        home_dotfiles: discover_home_dotfiles(
-            private_home,
-            &config.hide_dotdirs,
-            &exempt,
-            verbose,
-        ),
+        home_dotfiles,
         config_hide: if private_home {
             vec![]
         } else {
@@ -961,6 +995,7 @@ fn discover_mounts(
         display_env,
         ssh_agent: ssh_agent_mount,
         ssh_env,
+        claude_env,
         pictures: pictures_mount,
         browser_state: browser_state_mount,
         extra: if lockdown || browser_mode {
@@ -2361,6 +2396,85 @@ mod tests {
         assert_eq!(
             selected.file_name().and_then(|s| s.to_str()),
             Some("bwrap")
+        );
+    }
+
+    #[test]
+    fn claude_dir_produces_bind_mount_and_setenv() {
+        let tmp_root = std::env::temp_dir()
+            .join(format!("ai-jail-bwrap-claude-{}", std::process::id()));
+        let claude_dir = tmp_root.join(".claude-example");
+        let _ = std::fs::create_dir_all(&claude_dir);
+
+        let config = Config {
+            command: vec!["claude".into()],
+            claude_dir: Some(claude_dir.clone()),
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            no_display: Some(true),
+            ..Config::default()
+        };
+        let project = PathBuf::from("/tmp/project");
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            Path::new("/tmp/hosts"),
+            None,
+            Path::new("/tmp/empty"),
+            false,
+        )
+        .unwrap();
+
+        let bind_pos = args.windows(3).position(|w| {
+            w[0] == "--bind"
+                && w[1] == claude_dir.display().to_string()
+                && w[2] == claude_dir.display().to_string()
+        });
+        assert!(
+            bind_pos.is_some(),
+            "--bind for claude_dir not found in argv: {args:?}"
+        );
+
+        let setenv_pos = args.windows(3).position(|w| {
+            w[0] == "--setenv"
+                && w[1] == "CLAUDE_CONFIG_DIR"
+                && w[2] == claude_dir.display().to_string()
+        });
+        assert!(
+            setenv_pos.is_some(),
+            "--setenv CLAUDE_CONFIG_DIR not found in argv: \
+             {args:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[test]
+    fn no_claude_dir_no_setenv() {
+        let config = Config {
+            command: vec!["claude".into()],
+            claude_dir: None,
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            no_display: Some(true),
+            ..Config::default()
+        };
+        let project = PathBuf::from("/tmp/project");
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            Path::new("/tmp/hosts"),
+            None,
+            Path::new("/tmp/empty"),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !args.iter().any(|a| a == "CLAUDE_CONFIG_DIR"),
+            "CLAUDE_CONFIG_DIR must not appear when \
+             claude_dir is None"
         );
     }
 }

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -520,6 +520,22 @@ fn collect_normal_paths(
         rw.push(claude_json);
     }
 
+    // claude_dir: read-write — custom directory for Claude Code
+    // configuration (CLAUDE.md, settings, etc.). Specified via
+    // --claude-dir flag or config. Must be writable so the
+    // agent can read/write its configuration files.
+    if let Some(dir) = &config.claude_dir
+        && super::path_exists(dir)
+    {
+        if verbose {
+            output::verbose(&format!(
+                "Landlock: claude-dir {} rw",
+                dir.display()
+            ));
+        }
+        rw.push(dir.clone());
+    }
+
     // $HOME/.gitconfig: read-only — git needs user.name and
     // user.email for commits, but the agent must not modify
     // the user's git identity or credential helpers.
@@ -1157,5 +1173,63 @@ mod tests {
             path,
             &fixture.common_dir
         )));
+    }
+
+    #[test]
+    fn normal_paths_claude_dir_is_writable() {
+        let tmp_root = std::env::temp_dir()
+            .join(format!("ai-jail-landlock-claude-{}", std::process::id()));
+        let claude_dir = tmp_root.join(".claude-example");
+        let _ = std::fs::create_dir_all(&claude_dir);
+
+        let config = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            claude_dir: Some(claude_dir.clone()),
+            ..Config::default()
+        };
+        let (_, rw) = collect_normal_paths(&config, Path::new("/tmp"), false);
+        assert!(
+            rw.contains(&claude_dir),
+            "claude_dir must be in Landlock rw paths"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[test]
+    fn normal_paths_no_claude_dir_unchanged() {
+        let tmp_root = std::env::temp_dir()
+            .join(format!("ai-jail-landlock-neg-{}", std::process::id()));
+        let claude_dir = tmp_root.join(".claude-neg");
+        let _ = std::fs::create_dir_all(&claude_dir);
+
+        let without = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            claude_dir: None,
+            ..Config::default()
+        };
+        let (_, rw_without) =
+            collect_normal_paths(&without, Path::new("/tmp"), false);
+        assert!(
+            !rw_without.contains(&claude_dir),
+            "claude_dir must not appear when None"
+        );
+
+        let with = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            claude_dir: Some(claude_dir.clone()),
+            ..Config::default()
+        };
+        let (_, rw_with) =
+            collect_normal_paths(&with, Path::new("/tmp"), false);
+        assert!(
+            rw_with.contains(&claude_dir),
+            "claude_dir must appear when set"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
     }
 }

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -69,6 +69,10 @@ pub fn build(config: &Config, project_dir: &Path, verbose: bool) -> Command {
     cmd.env("PS1", "(jail) \\w \\$ ");
     cmd.env("_ZO_DOCTOR", "0");
 
+    if let Some(dir) = &config.claude_dir {
+        cmd.env("CLAUDE_CONFIG_DIR", dir);
+    }
+
     cmd
 }
 
@@ -383,6 +387,12 @@ fn macos_writable_paths(
         let claude_json = home.join(".claude.json");
         if claude_json.is_file() {
             paths.push(claude_json);
+        }
+    }
+
+    if let Some(dir) = &config.claude_dir {
+        if super::path_exists(dir) {
+            paths.push(dir.clone());
         }
     }
 


### PR DESCRIPTION
Claude Code supports `CLAUDE_CONFIG_DIR` to use a non-default config directory, enabling multiple independent profiles (e.g. `~/.claude` for work, `~/.claude-personal` for a separate account). ai-jail doesn't expose this — `DOTDIR_RW` is hardcoded to `.claude`, and there's no way to mount a different directory rw or inject the env var into the sandbox.

```bash
# Without this PR:
ai-jail claude  # always uses ~/.claude, no way to switch

# With this PR:
ai-jail --claude-dir ~/.claude-work --init claude
ai-jail claude  # claude_dir persisted in .ai-jail, uses ~/.claude-work
```

### What changed

| File | Change |
|------|--------|
| `src/cli.rs` | Parse `--claude-dir <PATH>`, add to `CliArgs` |
| `src/config.rs` | `claude_dir: Option<PathBuf>` with `#[serde(default)]`, tilde expansion, merge logic |
| `src/sandbox/bwrap.rs` | rw bind mount + `--setenv CLAUDE_CONFIG_DIR` + pass flag to landlock wrapper |
| `src/sandbox/landlock.rs` | Add `claude_dir` to rw paths |
| `src/sandbox/seatbelt.rs` | Add writable path + `CLAUDE_CONFIG_DIR` env var |
| `src/bootstrap.rs` | `claude_config_path()` accepts `Option<&Path>`, writes `settings.json` to correct dir |
| `src/main.rs` | Thread `config.claude_dir` into `bootstrap::run()` |

### How to verify

```bash
# Tests:
cargo test 2>&1 | tail -5
# → 0 failures

# Dry-run:
mkdir -p /tmp/claude-test-dir
./target/release/ai-jail --dry-run --no-gpu --claude-dir /tmp/claude-test-dir claude 2>&1 \
  | grep -E "bind.*claude-test-dir|CLAUDE_CONFIG_DIR"
# → --bind /tmp/claude-test-dir /tmp/claude-test-dir
# → --setenv CLAUDE_CONFIG_DIR /tmp/claude-test-dir

# Live:
./target/release/ai-jail --no-gpu --claude-dir ~/.claude-other claude
# → Claude starts with the profile from ~/.claude-other
```

### Backward compatibility

- `claude_dir` defaults to `None` — zero behavior change when the flag is absent
- Old `.ai-jail` files without the field parse correctly (`#[serde(default)]`)
- Field omitted from generated configs when unused (`skip_serializing_if`)
- Regression test `regression_v0_9_0_config_without_claude_dir` verifies old format loads
- No existing CLI flag or config field removed, renamed, or retyped

### Tests added

**cli**: `parse_claude_dir`, `parse_claude_dir_missing_value_errors`
**config**: `regression_v0_9_0_config_without_claude_dir`, `parse_claude_dir_from_toml`, `merge_claude_dir_from_cli`, `merge_claude_dir_expands_tilde`, `merge_cli_no_claude_dir_preserves_config_claude_dir`, `merge_expands_tilde_from_config_file`, `roundtrip_claude_dir`, `roundtrip_claude_dir_none_not_written`
**bwrap**: `claude_dir_produces_bind_mount_and_setenv`, `no_claude_dir_no_setenv`
**landlock**: `normal_paths_claude_dir_is_writable`, `normal_paths_no_claude_dir_unchanged`
**bootstrap**: `claude_config_path_uses_custom_dir`, `claude_config_path_defaults_to_dot_claude`