### PR TITLE
Update SBPL pattern for claude timestamp on MacOS

### DIFF
--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -307,7 +307,7 @@ fn generate_sbpl_profile(
                 ));
                 let regex_escaped = sbpl_regex_escape(&path_str);
                 let siblings = format!(
-                    "^{regex_escaped}(\\.tmp\\.[0-9]+\\.[0-9]+|\\.lock)$"
+                    "^{regex_escaped}(\\.tmp\\.[0-9]+\\.[0-9a-f]+|\\.lock)$"
                 );
                 profile.push_str(&format!(
                     "(allow file-write* (regex #\"{siblings}\"))\n"
@@ -737,7 +737,7 @@ mod tests {
         );
         let bounded = format!(
             "(allow file-write* (regex #\"^{regex_escaped}\
-             (\\.tmp\\.[0-9]+\\.[0-9]+|\\.lock)$\"))"
+             (\\.tmp\\.[0-9]+\\.[0-9a-f]+|\\.lock)$\"))"
         );
         assert!(
             profile.contains(&bounded),


### PR DESCRIPTION
New pattern allows for hexdecimal timestamping

Fix https://github.com/akitaonrails/ai-jail/issues/44

Running:

```
ai-jail --dry-run claude
```

Changes from: 

```
...
; Atomic-write paths (literal + bounded temp siblings)
(allow file-write* (literal "/Users/brodock/.claude.json"))
(allow file-write* (regex #"^/Users/brodock/\.claude\.json(\.tmp\.[0-9]+\.[0-9]+|\.lock)$"))
```

to:

```
...
; Atomic-write paths (literal + bounded temp siblings)
(allow file-write* (literal "/Users/brodock/.claude.json"))
(allow file-write* (regex #"^/Users/brodock/\.claude\.json(\.tmp\.[0-9]+\.[0-9a-f]+|\.lock)$"))
```