### PR TITLE
Run mise trust with quiet flag

### DIFF
--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -359,7 +359,7 @@ fn mise_wrapper_command(
     user_cmd: LaunchCommand,
 ) -> LaunchCommand {
     // Command argv is passed via "$@" to avoid shell interpretation of user arguments.
-    let script = "MISE=\"$1\"; shift; \"$MISE\" trust && eval \"$($MISE activate bash)\" && eval \"$($MISE env)\" && exec \"$@\"";
+    let script = "MISE=\"$1\"; shift; \"$MISE\" trust -q && eval \"$($MISE activate bash)\" && eval \"$($MISE env)\" && exec \"$@\"";
     let mut args = vec![
         "-lc".into(),
         script.into(),


### PR DESCRIPTION
`mise trust` invocation in many cases will produce a warning message like `mise WARN  No untrusted config files found.` when executed in a folder where all configs are already trusted. It doesn't affect anything functionally, just slightly annoying, especially in something like one off question workflows where just explicit answer output is expected.

This adds `-q` flag which suppresses non error messages