### PR TITLE
Fix aur build on Manjaro

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -37,6 +37,9 @@ build() {
 check() {
     cd "$pkgname-$pkgver"
     export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    # Pin CARGO_HOME to the real cargo cache (populated by prepare()/build())
+    export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     export HOME="$srcdir/test-home"
     mkdir -p "$HOME"
     # Keep AUR builds robust across user kernels/containers: run the unit test


### PR DESCRIPTION
`makepkg` fails during `check()` with:

```
==> Starting check()...
error: no matching package named serde found
location searched: crates.io index
required by package ai-jail v1.4.0 (.../src/ai-jail-1.4.0)
```

`check()` overrides `HOME` to give tests a clean home, but cargo derives `CARGO_HOME` from `HOME`, repointing it at the empty $srcdir/test-home/.cargo.
Under --frozen this fails to find the crates fetched by  prepare()/build() ("no matching package named `serde` found").

Pin `CARGO_HOME` to the real cache before overriding `HOME`, and set `CARGO_TARGET_DIR=target` to match `build()`.

Patch generated by Claude, I don't know aur.