### PR TITLE
Add copy-on-write overlay maps (--overlay-map) (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,12 @@ The bwrap command mounts are order-dependent. The sequence in `sandbox.rs` must 
 13. Pictures mount
 14. Browser profile state mount
 15. Extra user mounts (`--map`, `--rw-map`)
-16. Project directory (pwd, rw or ro depending on mode)
-17. Mask overlays (`--mask` and hidden project `.ai-jail`)
+16. Overlay maps (`--overlay-map` — copy-on-write `--overlay-src`/`--overlay`)
+17. Project directory (pwd, rw or ro depending on mode)
+18. Mask overlays (`--mask` and hidden project `.ai-jail`)
+19. Overlay storage hide (tmpfs over `<project>/.ai-jail-overlays`, last so it sits on top of the project mount that contains the upper/work layers)
 
-Changing this order can break the sandbox. The tmpfs for `$HOME` must come before the individual dotfile bind mounts.
+Changing this order can break the sandbox. The tmpfs for `$HOME` must come before the individual dotfile bind mounts. Overlay maps come after the home/dotfile mounts (so an overlay on a home path sits on top) and their storage hide comes after the project mount (so it masks the layers the project mount would otherwise expose).
 
 ## Before Committing
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ ai-jail drops a `.gitignore` (`*`) inside `.ai-jail-overlays/` automatically, so
 - **Linux/bwrap only.** Backed by bubblewrap's `--overlay`, which needs unprivileged OverlayFS (Linux kernel ≥ 5.11). On **macOS** there is no equivalent, so overlay maps degrade to **read-only** with a warning (writes are denied, protecting the original).
 - **Disabled under `--lockdown` and browser mode** (both are read-only/ephemeral by design); a warning is printed if overlay maps are configured there.
 - Missing sources, unwritable storage, or overlapping destinations are skipped with a warning — never fatal.
+- **Storage is created eagerly.** The `.ai-jail-overlays/` directory (with its auto `.gitignore`) is created as soon as an overlay map is configured — including under `--dry-run`, because the upper/work layers must exist on disk before OverlayFS can mount them. It is git-ignored automatically; delete it any time with `rm -rf .ai-jail-overlays/`.
 
 ## Config file (`.ai-jail`)
 

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ If no command is given and no `.ai-jail` config exists, defaults to `bash`.
 |------|-------------|
 | `--rw-map <PATH>` | Mount PATH read-write (repeatable). Relative paths and `..` are resolved against the project directory, so `--rw-map ../sister-project` works from a project root. |
 | `--map <PATH>` | Mount PATH read-only (repeatable). Same path resolution as `--rw-map`. |
+| `--overlay-map <PATH>` | Mount PATH **copy-on-write** (repeatable). The agent sees PATH read-write, but writes land on a side layer under `<project>/.ai-jail-overlays/` while PATH itself is never modified — so you can diff and selectively promote changes afterwards. Opt-in only. Linux/bwrap only; degrades to **read-only** (with a warning) on macOS, and is disabled under `--lockdown` / browser mode. See [Overlay maps](#overlay-maps). |
 | `--hide-dotdir <NAME>` | Never bind-mount the named home dotdir into the sandbox (e.g. `.my_secrets`). Leading dot is optional. Repeatable. Cannot hide dotdirs required for tool operation (`.cargo`, `.config`, `.cache`, etc.) — those emit a warning and stay visible. |
 | `--mask <PATH>` | Replace `PATH` inside the sandbox with an empty file (or empty tmpfs if the path is a directory). Relative paths resolve against the project directory. Repeatable. Useful for hiding sensitive files like `.env`, `credentials.json` from AI agents while keeping the rest of the project accessible. Missing paths are skipped with a warning. |
 | `--allow-tcp-port <PORT>` | Permit outbound TCP to PORT in lockdown mode (repeatable). Skips `--unshare-net` and uses Landlock V4 `NetPort` rules to deny everything else. Requires Linux ≥ 6.5; hard-fails otherwise. No effect outside lockdown or on macOS. |
@@ -483,6 +484,9 @@ ai-jail --rw-map ~/Projects/shared-lib claude
 
 # Read-only access to reference data
 ai-jail --map /opt/datasets claude
+
+# Let the agent experiment with ~/.claude without touching the real one
+ai-jail --overlay-map ~/.claude claude
 
 # No GPU, no Docker, just the basics
 ai-jail --no-gpu --no-docker claude
@@ -534,6 +538,49 @@ ai-jail --clean --init claude
 ai-jail -- claude --model opus
 ```
 
+## Overlay maps
+
+`--overlay-map <PATH>` (config: `overlay_maps`) mounts a directory **copy-on-write**. Inside the sandbox the agent sees `PATH` as a normal read-write directory, but every write — new file, edit, or delete — lands on a private *upper* layer instead of the real directory. **The original `PATH` is never modified.**
+
+This lets an agent freely experiment with something you care about (your `~/.claude` config, a dotfiles repo, a data directory) while you keep the original safe and decide afterwards what — if anything — to keep.
+
+```bash
+# The agent can rewrite ~/.claude all it wants; your real one is untouched
+ai-jail --overlay-map ~/.claude claude
+```
+
+### Where the changes go
+
+Writes are captured under the project directory:
+
+```
+<project>/.ai-jail-overlays/<sanitized-path>/upper/   # exactly what changed
+<project>/.ai-jail-overlays/<sanitized-path>/work/    # overlayfs scratch (ignore)
+```
+
+The `upper/` layer contains *only* the files the agent created or changed — so it doubles as a precise diff. After a session you can inspect it and promote what you want:
+
+```bash
+# See what the agent changed
+ls -R .ai-jail-overlays/home_you_.claude/upper/
+
+# Promote a change you like back to the real directory
+cp .ai-jail-overlays/home_you_.claude/upper/settings.json ~/.claude/settings.json
+
+# Or throw the whole experiment away
+rm -rf .ai-jail-overlays/
+```
+
+ai-jail drops a `.gitignore` (`*`) inside `.ai-jail-overlays/` automatically, so the layers are never accidentally committed. The storage directory is masked (empty tmpfs) inside the sandbox, so the agent cannot reach or tamper with the raw layers — it can only go through the overlay at the destination.
+
+### Notes and limits
+
+- **Opt-in only.** Nothing overlays unless you pass `--overlay-map` / set `overlay_maps`. All existing behavior is unchanged.
+- **Multiple overlays** are allowed as long as their destinations don't overlap (a parent and its child are rejected with a warning).
+- **Linux/bwrap only.** Backed by bubblewrap's `--overlay`, which needs unprivileged OverlayFS (Linux kernel ≥ 5.11). On **macOS** there is no equivalent, so overlay maps degrade to **read-only** with a warning (writes are denied, protecting the original).
+- **Disabled under `--lockdown` and browser mode** (both are read-only/ephemeral by design); a warning is printed if overlay maps are configured there.
+- Missing sources, unwritable storage, or overlapping destinations are skipped with a warning — never fatal.
+
 ## Config file (`.ai-jail`)
 
 Created in the project directory on first run. Example:
@@ -569,6 +616,7 @@ When CLI flags and an existing config are both present:
 | `command` | string array | `["bash"]` | Default command to run inside sandbox. Set by first run or by `--init`; not overwritten when a different command is passed on the CLI. |
 | `rw_maps` | path array | `[]` | Extra read-write mounts |
 | `ro_maps` | path array | `[]` | Extra read-only mounts |
+| `overlay_maps` | path array | `[]` | Extra copy-on-write overlay mounts (see [Overlay maps](#overlay-maps)). Writes go to a side layer; the source stays untouched. Linux/bwrap only. |
 | `hide_dotdirs` | string array | `[]` | Extra home dotdirs to deny (e.g. `[".my_secrets"]`). Leading dot optional. Built-in deny list (`.ssh`, `.gnupg`, `.aws`, `.mozilla`) always applies. |
 | `mask` | path array | `[]` | Paths to replace with empty files/tmpfs (e.g. `[".env", "secrets.json"]`). Relative paths resolve against the project directory. |
 | `allow_tcp_ports` | u16 array | `[]` | TCP ports permitted outbound in lockdown mode (e.g. `[32000, 8080]`). Requires Linux ≥ 6.5 for Landlock V4. No effect outside lockdown. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,10 @@ COMMANDS (positional):
 OPTIONS:
     --rw-map <PATH>                Mount PATH read-write inside sandbox (repeatable)
     --map <PATH>                   Mount PATH read-only inside sandbox (repeatable)
+    --overlay-map <PATH>           Mount PATH copy-on-write: writes go to a side
+                                   layer, PATH itself stays untouched so you can
+                                   diff/promote later (repeatable; Linux/bwrap
+                                   only, read-only on macOS)
     --hide-dotdir <NAME>           Never mount dotdir NAME (e.g., .my_secrets) (repeatable)
     --mask <PATH>                  Replace PATH with an empty file inside sandbox (repeatable)
     --private-home / --no-private-home
@@ -57,6 +61,7 @@ pub struct CliArgs {
     pub command: Vec<String>,
     pub rw_maps: Vec<PathBuf>,
     pub ro_maps: Vec<PathBuf>,
+    pub overlay_maps: Vec<PathBuf>,
     pub hide_dotdirs: Vec<String>,
     pub mask: Vec<PathBuf>,
     pub private_home: Option<bool>,
@@ -110,6 +115,11 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
                 let val: PathBuf =
                     parser.value().map_err(|e| e.to_string())?.into();
                 args.ro_maps.push(val);
+            }
+            Long("overlay-map") => {
+                let val: PathBuf =
+                    parser.value().map_err(|e| e.to_string())?.into();
+                args.overlay_maps.push(val);
             }
             Long("mask") => {
                 let val = parser.value().map_err(|e| e.to_string())?;
@@ -557,6 +567,25 @@ mod tests {
     fn parse_rw_map() {
         let args = parse_test(&["--rw-map", "/tmp/test", "bash"]).unwrap();
         assert_eq!(args.rw_maps, vec![PathBuf::from("/tmp/test")]);
+    }
+
+    #[test]
+    fn parse_overlay_map() {
+        let args = parse_test(&[
+            "--overlay-map",
+            "/home/u/.claude",
+            "--overlay-map",
+            "/home/u/.config/foo",
+            "bash",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.overlay_maps,
+            vec![
+                PathBuf::from("/home/u/.claude"),
+                PathBuf::from("/home/u/.config/foo"),
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,12 @@ pub struct Config {
     pub rw_maps: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ro_maps: Vec<PathBuf>,
+    /// Copy-on-write overlay mounts: PATH is visible read-write inside
+    /// the sandbox, but writes land on a side layer under
+    /// `<project>/.ai-jail-overlays/` while the original stays
+    /// untouched (Linux/bwrap only; read-only fallback on macOS).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlay_maps: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hide_dotdirs: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -218,6 +224,8 @@ pub fn merge_with_global(global: Config, local: Config) -> Config {
     dedup_paths(&mut c.rw_maps);
     c.ro_maps.extend(local.ro_maps);
     dedup_paths(&mut c.ro_maps);
+    c.overlay_maps.extend(local.overlay_maps);
+    dedup_paths(&mut c.overlay_maps);
     c.hide_dotdirs.extend(local.hide_dotdirs);
     dedup_strings(&mut c.hide_dotdirs);
     c.mask.extend(local.mask);
@@ -308,6 +316,7 @@ fn save_to_path(path: &Path, config: &Config) {
     let mut on_disk = config.clone();
     collapse_tilde_vec(&mut on_disk.rw_maps);
     collapse_tilde_vec(&mut on_disk.ro_maps);
+    collapse_tilde_vec(&mut on_disk.overlay_maps);
     collapse_tilde_vec(&mut on_disk.mask);
     if let Some(p) = on_disk.claude_dir.take() {
         on_disk.claude_dir = Some(collapse_tilde(&p));
@@ -445,6 +454,7 @@ fn absolutize_vec(paths: &mut [PathBuf], base: &Path) {
 pub fn absolutize_user_paths(config: &mut Config, cwd: &Path) {
     absolutize_vec(&mut config.rw_maps, cwd);
     absolutize_vec(&mut config.ro_maps, cwd);
+    absolutize_vec(&mut config.overlay_maps, cwd);
 }
 
 /// Inverse of `expand_tilde`: if `path` starts with `$HOME`, rewrite
@@ -495,6 +505,9 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
 
     config.ro_maps.extend(cli.ro_maps.iter().cloned());
     dedup_paths(&mut config.ro_maps);
+
+    config.overlay_maps.extend(cli.overlay_maps.iter().cloned());
+    dedup_paths(&mut config.overlay_maps);
 
     // hide_dotdirs: CLI values appended, deduplicated
     config.hide_dotdirs.extend(cli.hide_dotdirs.iter().cloned());
@@ -565,6 +578,7 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     // tilde is recognized; `~user` is left alone.
     expand_tilde_vec(&mut config.rw_maps);
     expand_tilde_vec(&mut config.ro_maps);
+    expand_tilde_vec(&mut config.overlay_maps);
     expand_tilde_vec(&mut config.mask);
     if let Some(p) = config.claude_dir.take() {
         config.claude_dir = Some(expand_tilde(p));
@@ -584,6 +598,7 @@ pub fn display_status(config: &Config) {
     print_command(config);
     print_path_list("  RW maps", &config.rw_maps);
     print_path_list("  RO maps", &config.ro_maps);
+    print_path_list("  Overlay maps", &config.overlay_maps);
     print_string_list("  Hide dotdirs", &config.hide_dotdirs);
     print_path_list("  Masked files", &config.mask);
 
@@ -1023,6 +1038,39 @@ allow_tcp_ports = []
     }
 
     #[test]
+    fn regression_v1_7_0_config_without_overlay_maps() {
+        // Configs written before overlay_maps existed must still parse,
+        // defaulting the new field to an empty list.
+        let toml = r#"
+command = ["claude"]
+rw_maps = ["/tmp/rw"]
+ro_maps = ["/opt/ro"]
+hide_dotdirs = []
+mask = []
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.rw_maps, vec![PathBuf::from("/tmp/rw")]);
+        assert_eq!(cfg.ro_maps, vec![PathBuf::from("/opt/ro")]);
+        assert!(cfg.overlay_maps.is_empty());
+    }
+
+    #[test]
+    fn parse_config_with_overlay_maps() {
+        let toml = r#"
+command = ["claude"]
+overlay_maps = ["/home/u/.claude", "/home/u/.config/foo"]
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(
+            cfg.overlay_maps,
+            vec![
+                PathBuf::from("/home/u/.claude"),
+                PathBuf::from("/home/u/.config/foo"),
+            ]
+        );
+    }
+
+    #[test]
     fn regression_empty_config_file() {
         // An empty .ai-jail file must not crash
         let cfg = parse_toml("").unwrap();
@@ -1044,6 +1092,7 @@ allow_tcp_ports = []
             command: vec!["claude".into()],
             rw_maps: vec![PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")],
             ro_maps: vec![PathBuf::from("/opt/data")],
+            overlay_maps: vec![PathBuf::from("/home/u/.claude")],
             hide_dotdirs: vec![".my_secrets".into(), ".proton".into()],
             mask: vec![PathBuf::from(".env")],
             no_gpu: Some(true),
@@ -1951,6 +2000,7 @@ allow_tcp_ports = [32000, 8080]
             command: vec!["codex".into()],
             rw_maps: vec![PathBuf::from("/tmp/shared")],
             ro_maps: vec![],
+            overlay_maps: vec![],
             hide_dotdirs: vec![],
             mask: vec![],
             no_gpu: Some(true),

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -12,14 +12,44 @@ const WSL_DOCKER_DESKTOP_CLI_TOOLS: &str = "/mnt/wsl/docker-desktop/cli-tools";
 
 #[derive(Debug, Clone)]
 enum Mount {
-    RoBind { src: PathBuf, dest: PathBuf },
-    Bind { src: PathBuf, dest: PathBuf },
-    DevBind { src: PathBuf, dest: PathBuf },
-    Dev { dest: PathBuf },
-    Proc { dest: PathBuf },
-    Tmpfs { dest: PathBuf },
-    Symlink { src: String, dest: PathBuf },
-    FileRoBind { src: PathBuf, dest: PathBuf },
+    RoBind {
+        src: PathBuf,
+        dest: PathBuf,
+    },
+    Bind {
+        src: PathBuf,
+        dest: PathBuf,
+    },
+    DevBind {
+        src: PathBuf,
+        dest: PathBuf,
+    },
+    Dev {
+        dest: PathBuf,
+    },
+    Proc {
+        dest: PathBuf,
+    },
+    Tmpfs {
+        dest: PathBuf,
+    },
+    Symlink {
+        src: String,
+        dest: PathBuf,
+    },
+    FileRoBind {
+        src: PathBuf,
+        dest: PathBuf,
+    },
+    /// Copy-on-write overlay: `lower` is mounted read-only as the base
+    /// at `dest`, writes go to `upper` (with overlayfs scratch in
+    /// `work`). The original `lower` directory is never modified.
+    Overlay {
+        lower: PathBuf,
+        upper: PathBuf,
+        work: PathBuf,
+        dest: PathBuf,
+    },
 }
 
 impl Mount {
@@ -62,6 +92,23 @@ impl Mount {
                     dest.display().to_string(),
                 ]
             }
+            Mount::Overlay {
+                lower,
+                upper,
+                work,
+                dest,
+            } => {
+                // `--overlay-src` sets the read-only lower layer for
+                // the `--overlay` that immediately follows it.
+                vec![
+                    "--overlay-src".into(),
+                    lower.display().to_string(),
+                    "--overlay".into(),
+                    upper.display().to_string(),
+                    work.display().to_string(),
+                    dest.display().to_string(),
+                ]
+            }
         }
     }
 }
@@ -85,12 +132,17 @@ struct MountSet {
     pictures: Vec<Mount>,
     browser_state: Vec<Mount>,
     extra: Vec<Mount>,
+    overlay: Vec<Mount>,
     project: Vec<Mount>,
     mask: Vec<Mount>,
+    /// tmpfs that hides the on-host overlay upper/work storage from
+    /// inside the sandbox. Applied last so it sits on top of the
+    /// project mount that contains it.
+    overlay_hide: Vec<Mount>,
 }
 
 impl MountSet {
-    fn ordered_mounts(&self) -> [&[Mount]; 17] {
+    fn ordered_mounts(&self) -> [&[Mount]; 19] {
         [
             &self.base,
             &self.sys_masks,
@@ -107,8 +159,10 @@ impl MountSet {
             &self.pictures,
             &self.browser_state,
             &self.extra,
+            &self.overlay,
             &self.project,
             &self.mask,
+            &self.overlay_hide,
         ]
     }
 
@@ -941,6 +995,19 @@ fn discover_mounts(
         lockdown,
         verbose,
     );
+    // Overlay maps are opt-in and only meaningful when the sandbox
+    // can write: disabled under lockdown (read-only) and browser mode.
+    let (overlay_mounts_v, overlay_hide_v) = if lockdown || browser_mode {
+        if !config.overlay_maps.is_empty() {
+            output::warn(
+                "Overlay maps are disabled under lockdown/browser \
+                     mode; skipping.",
+            );
+        }
+        (vec![], vec![])
+    } else {
+        overlay_mounts(&config.overlay_maps, project_dir, verbose)
+    };
 
     MountSet {
         base: discover_base(hosts_file, resolv_mount),
@@ -985,8 +1052,10 @@ fn discover_mounts(
         } else {
             extra_mounts(&config.rw_maps, &config.ro_maps)
         },
+        overlay: overlay_mounts_v,
         project: project_mount(project_dir, lockdown || browser_mode),
         mask: mask_mounts,
+        overlay_hide: overlay_hide_v,
     }
 }
 
@@ -1623,6 +1692,141 @@ fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
     }
 
     mounts
+}
+
+/// Directory (inside the project) that holds the on-host upper and
+/// work layers for overlay maps. Masked from inside the sandbox.
+const OVERLAY_STORAGE_DIR: &str = ".ai-jail-overlays";
+
+/// Turn an absolute destination path into a filesystem-safe, readable
+/// directory name for its overlay layer storage. `/home/u/.claude`
+/// becomes `home_u_.claude`. Preserving the full path keeps distinct
+/// destinations collision-free.
+fn overlay_storage_name(dest: &Path) -> String {
+    let s = dest.to_string_lossy();
+    let mut name = String::with_capacity(s.len());
+    for ch in s.trim_start_matches('/').chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+            name.push(ch);
+        } else {
+            name.push('_');
+        }
+    }
+    if name.is_empty() {
+        name.push_str("root");
+    }
+    name
+}
+
+/// Build overlayfs mounts for `--overlay-map` destinations, plus the
+/// tmpfs that hides their on-host upper/work storage from inside the
+/// sandbox.
+///
+/// Each map mounts the real directory (read-only lower) at the same
+/// path inside the sandbox with a writable upper layer under
+/// `<project>/.ai-jail-overlays/<name>/upper`. Writes land in the
+/// upper layer; the original directory is never modified, so the user
+/// can diff the upper layer afterwards and promote changes.
+///
+/// Returns `(overlay_mounts, storage_hide_mounts)`. Overlays that
+/// cannot be set up (missing source, unwritable storage, overlapping
+/// destination) are skipped with a warning — never fatal.
+fn overlay_mounts(
+    overlay_maps: &[PathBuf],
+    project_dir: &Path,
+    verbose: bool,
+) -> (Vec<Mount>, Vec<Mount>) {
+    if overlay_maps.is_empty() {
+        return (vec![], vec![]);
+    }
+    let storage_root = project_dir.join(OVERLAY_STORAGE_DIR);
+    let mut mounts = Vec::new();
+    let mut accepted: Vec<PathBuf> = Vec::new();
+
+    for dest in overlay_maps {
+        if !super::path_exists(dest) {
+            output::warn(&format!(
+                "Overlay map {} not found, skipping.",
+                dest.display()
+            ));
+            continue;
+        }
+        // Reject overlapping destinations (equal / parent / child):
+        // two overlays sharing a subtree give overlayfs ambiguous
+        // layering and risk silent data confusion.
+        if let Some(conflict) = accepted
+            .iter()
+            .find(|a| *a == dest || a.starts_with(dest) || dest.starts_with(a))
+        {
+            output::warn(&format!(
+                "Overlay map {} overlaps {}, skipping.",
+                dest.display(),
+                conflict.display()
+            ));
+            continue;
+        }
+
+        let base = storage_root.join(overlay_storage_name(dest));
+        let upper = base.join("upper");
+        let work = base.join("work");
+        if let Err(e) = std::fs::create_dir_all(&upper)
+            .and_then(|_| std::fs::create_dir_all(&work))
+        {
+            output::warn(&format!(
+                "Overlay map {}: cannot create layer storage {}: {e}; \
+                 skipping.",
+                dest.display(),
+                base.display()
+            ));
+            continue;
+        }
+
+        // Always surface this, even without --verbose: the feature is
+        // opt-in and the whole point is that writes do NOT touch the
+        // original. Tell the user where the captured changes live so
+        // nobody loses work unknowingly.
+        output::info(&format!(
+            "Overlay: {} is copy-on-write; changes captured in {} \
+             (original untouched)",
+            dest.display(),
+            upper.display()
+        ));
+
+        mounts.push(Mount::Overlay {
+            lower: dest.clone(),
+            upper,
+            work,
+            dest: dest.clone(),
+        });
+        accepted.push(dest.clone());
+    }
+
+    if mounts.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    // Drop a .gitignore so overlay layers never get committed by
+    // accident, then hide the raw storage from inside the sandbox so
+    // the agent cannot read or tamper with the upper/work layers
+    // directly — it must go through the overlay mount at the dest.
+    write_overlay_gitignore(&storage_root);
+    if verbose {
+        output::verbose(&format!("Overlay maps: {} active", mounts.len()));
+    }
+    let hide = vec![Mount::Tmpfs { dest: storage_root }];
+    (mounts, hide)
+}
+
+/// Write a `.gitignore` into the overlay storage root so the layers
+/// are never accidentally committed. Best-effort; failure is silent.
+fn write_overlay_gitignore(storage_root: &Path) {
+    let gitignore = storage_root.join(".gitignore");
+    if !super::path_exists(&gitignore) {
+        let _ = std::fs::write(
+            &gitignore,
+            "# ai-jail overlay layers — do not commit\n*\n",
+        );
+    }
 }
 
 fn project_mount(project_dir: &Path, readonly: bool) -> Vec<Mount> {
@@ -2292,6 +2496,170 @@ mod tests {
             .windows(3)
             .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
         assert!(!has_tmp_bind);
+    }
+
+    /// Create a fresh `(project_dir, source_dir)` pair under the temp
+    /// dir for overlay tests. Caller removes the parent when done.
+    fn overlay_test_dirs(prefix: &str) -> (PathBuf, PathBuf) {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-ovl-{prefix}-{}-{nonce}",
+            std::process::id()
+        ));
+        let project = root.join("project");
+        let source = root.join("source");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+        (project, source)
+    }
+
+    #[test]
+    fn mount_overlay_to_args() {
+        let m = Mount::Overlay {
+            lower: PathBuf::from("/home/u/.claude"),
+            upper: PathBuf::from("/p/.ai-jail-overlays/x/upper"),
+            work: PathBuf::from("/p/.ai-jail-overlays/x/work"),
+            dest: PathBuf::from("/home/u/.claude"),
+        };
+        assert_eq!(
+            m.to_args(),
+            vec![
+                "--overlay-src".to_string(),
+                "/home/u/.claude".into(),
+                "--overlay".into(),
+                "/p/.ai-jail-overlays/x/upper".into(),
+                "/p/.ai-jail-overlays/x/work".into(),
+                "/home/u/.claude".into(),
+            ]
+        );
+    }
+
+    #[test]
+    fn overlay_storage_name_sanitizes_path() {
+        assert_eq!(
+            overlay_storage_name(Path::new("/home/u/.claude")),
+            "home_u_.claude"
+        );
+        assert_eq!(overlay_storage_name(Path::new("/a b/c@d")), "a_b_c_d");
+    }
+
+    #[test]
+    fn overlay_mounts_creates_layers_and_hide() {
+        let (project, source) = overlay_test_dirs("create");
+        let (mounts, hide) =
+            overlay_mounts(std::slice::from_ref(&source), &project, false);
+
+        assert_eq!(mounts.len(), 1);
+        match &mounts[0] {
+            Mount::Overlay {
+                lower,
+                upper,
+                work,
+                dest,
+            } => {
+                assert_eq!(lower, &source);
+                assert_eq!(dest, &source);
+                assert!(upper.is_dir(), "upper layer must be created");
+                assert!(work.is_dir(), "work dir must be created");
+                assert!(upper.starts_with(project.join(".ai-jail-overlays")));
+            }
+            other => panic!("expected Overlay, got {other:?}"),
+        }
+
+        assert_eq!(hide.len(), 1);
+        match &hide[0] {
+            Mount::Tmpfs { dest } => {
+                assert_eq!(dest, &project.join(".ai-jail-overlays"));
+            }
+            other => panic!("expected Tmpfs hide, got {other:?}"),
+        }
+        assert!(
+            project.join(".ai-jail-overlays/.gitignore").is_file(),
+            "a .gitignore must guard the storage dir"
+        );
+
+        let _ = std::fs::remove_dir_all(project.parent().unwrap());
+    }
+
+    #[test]
+    fn overlay_mounts_skips_overlapping() {
+        let (project, source) = overlay_test_dirs("overlap");
+        let child = source.join("sub");
+        std::fs::create_dir_all(&child).unwrap();
+        // child overlaps source → only the first (source) is accepted.
+        let maps = vec![source.clone(), child];
+        let (mounts, _hide) = overlay_mounts(&maps, &project, false);
+        assert_eq!(mounts.len(), 1);
+        let _ = std::fs::remove_dir_all(project.parent().unwrap());
+    }
+
+    #[test]
+    fn overlay_mounts_skips_missing_source() {
+        let (project, _source) = overlay_test_dirs("missing");
+        let missing = project.join("does-not-exist");
+        let (mounts, hide) =
+            overlay_mounts(std::slice::from_ref(&missing), &project, false);
+        assert!(mounts.is_empty());
+        assert!(hide.is_empty());
+        let _ = std::fs::remove_dir_all(project.parent().unwrap());
+    }
+
+    #[test]
+    fn overlay_present_in_normal_mode() {
+        let (project, source) = overlay_test_dirs("normal");
+        let mut config = minimal_test_config();
+        config.overlay_maps = vec![source.clone()];
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(args.windows(2).any(|w| {
+            w[0] == "--overlay-src" && Path::new(&w[1]) == source
+        }));
+        assert!(args.iter().any(|a| a == "--overlay"));
+        // Raw storage is hidden from inside the sandbox.
+        let storage = project.join(".ai-jail-overlays");
+        assert!(
+            args.windows(2)
+                .any(|w| { w[0] == "--tmpfs" && Path::new(&w[1]) == storage })
+        );
+
+        let _ = std::fs::remove_dir_all(project.parent().unwrap());
+    }
+
+    #[test]
+    fn overlay_disabled_in_lockdown() {
+        let (project, source) = overlay_test_dirs("lockdown");
+        let mut config = minimal_test_config();
+        config.lockdown = Some(true);
+        config.overlay_maps = vec![source];
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_path(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        assert!(!args.iter().any(|a| a == "--overlay"));
+        let _ = std::fs::remove_dir_all(project.parent().unwrap());
     }
 
     #[test]

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -598,6 +598,21 @@ fn collect_normal_paths(
                 ));
             }
         }
+        // Overlay maps need read-write here: Landlock runs INSIDE the
+        // bwrap sandbox (via --landlock-exec), where the destination is
+        // already an overlayfs mount. Writing there lands in the upper
+        // layer, never the original — so granting rw is both required
+        // for the feature to work and safe for the source directory.
+        for p in &config.overlay_maps {
+            if super::path_exists(p) {
+                rw.push(p.clone());
+            } else {
+                output::warn(&format!(
+                    "Landlock: overlay map {} not found, skipping",
+                    p.display()
+                ));
+            }
+        }
         if verbose && (!config.rw_maps.is_empty() || !config.ro_maps.is_empty())
         {
             output::verbose("Landlock: extra maps");

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -34,6 +34,12 @@ pub fn platform_notes(config: &Config) {
              lockdown (seatbelt blocks all network)",
         );
     }
+    if !config.overlay_maps.is_empty() {
+        output::warn(
+            "overlay maps are read-only on macOS (no overlayfs); \
+             writes to those paths will be denied",
+        );
+    }
 }
 
 pub fn build(config: &Config, project_dir: &Path, verbose: bool) -> Command {
@@ -510,6 +516,16 @@ fn macos_lockdown_read_paths(
     {
         for path in worktree.unique_paths() {
             push_unique(canonicalize_or_keep(&path));
+        }
+    }
+
+    // Overlay maps degrade to read-only on macOS (no overlayfs), so
+    // they are always readable but never writable. Writes are denied
+    // because the paths are not in the writable set — this protects
+    // the original directory. A warning is emitted in platform_notes.
+    for p in &config.overlay_maps {
+        if super::path_exists(p) {
+            push_unique(canonicalize_or_keep(p));
         }
     }
 


### PR DESCRIPTION
Implements #58 — copy-on-write overlay maps.

## What

`--overlay-map <PATH>` (config: `overlay_maps`, repeatable) mounts a directory **copy-on-write**: the agent sees `PATH` as read-write, but every write lands on a private *upper* layer under `<project>/.ai-jail-overlays/<name>/upper` while the original `PATH` is **never modified**. The `upper/` layer is exactly the set of changes, so it doubles as a diff you can inspect and selectively promote afterwards.

```bash
ai-jail --overlay-map ~/.claude claude   # agent can rewrite ~/.claude; the real one stays safe
```

## Design (per the constraints set on the issue)

- **Fully opt-in.** Nothing overlays unless the flag/config is set — all existing behavior is unchanged. An info line is printed whenever an overlay is active, naming the upper-layer path, so changes are never silently lost.
- **Tamper-proof storage.** The raw upper/work layers are masked (empty tmpfs) inside the sandbox, so the agent must go through the overlay at the destination. A `.gitignore` (`*`) is auto-dropped so layers are never committed.
- **Backed by bwrap** `--overlay-src`/`--overlay` (Linux, unprivileged OverlayFS, kernel ≥ 5.11). Disabled under `--lockdown` and browser mode. Missing/overlapping/unwritable maps are skipped with a warning, never fatal.

## Platform behavior

- **Linux/bwrap:** bwrap mounts the overlay; Landlock (which always runs *inside* the bwrap sandbox via `--landlock-exec`) grants **read-write** to the destination — safe precisely because the overlay protects the original. Granting read-only there would break the feature.
- **macOS/seatbelt:** no OverlayFS, so overlay maps degrade to **read-only** with a warning — the source is readable but writes are denied, protecting the original. (This is the `Warn + read-only fallback` choice.)

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (440 pass, +10 new), and `cargo check --target aarch64-apple-darwin` all green locally.
- **End-to-end on Linux:** ran `--overlay-map` on a real dir, wrote/edited/added files inside the sandbox → original dir untouched on the host, changes captured in `upper/`, `.ai-jail-overlays` masked (empty) inside the sandbox, Landlock fully enforced throughout.

## Docs

README gains an Options-table row, an example, a config-field row, and a dedicated **Overlay maps** section (storage layout, diff/promote workflow, platform limits). CLAUDE.md mount-order updated (two new ordered slots).

## Open question for review

Like browser-profile state, the overlay storage dirs (+ `.gitignore`) are created during mount discovery, which means a `--dry-run` also creates them. Matches existing precedent, but happy to defer creation to real runs if you'd prefer dry-run to have zero side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
