### PR TITLE
Add .thunderbird to mount deny list

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Your real `$HOME` is replaced with a tmpfs. Dotfiles and dotdirs are selectively
 Pass `--private-home` or set `private_home = true` to skip this automatic dotdir layering entirely. `--ssh`, `--pictures`, `--map`, and `--rw-map` remain explicit opt-ins. On macOS, `sandbox-exec` does not provide tmpfs mounts, so ai-jail approximates this by denying normal host-home reads and writes.
 
 **Never mounted (sensitive data):**
-- `.gnupg`, `.aws`, `.ssh`, `.mozilla`, `.basilisk-dev`, `.sparrow`
+- `.gnupg`, `.aws`, `.ssh`, `.mozilla`, `.thunderbird`, `.basilisk-dev`, `.sparrow`
 
 **Mounted read-write (AI tools and build caches):**
 - `.gemini`, `.claude`, `.crush`, `.codex`, `.aider`, `.config`, `.cargo`, `.cache`, `.docker`

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -35,6 +35,7 @@ const DOTDIR_DENY: &[&str] = &[
     ".aws",
     ".ssh",
     ".mozilla",
+    ".thunderbird",
     ".basilisk-dev",
     ".sparrow",
 ];
@@ -1088,6 +1089,7 @@ mod tests {
             ".aws",
             ".ssh",
             ".mozilla",
+            ".thunderbird",
             ".basilisk-dev",
             ".sparrow",
         ] {
@@ -1140,6 +1142,7 @@ mod tests {
         assert!(is_dotdir_denied(".aws", &[], &[]));
         assert!(is_dotdir_denied(".ssh", &[], &[]));
         assert!(is_dotdir_denied(".mozilla", &[], &[]));
+        assert!(is_dotdir_denied(".thunderbird", &[], &[]));
         assert!(is_dotdir_denied(".basilisk-dev", &[], &[]));
         assert!(is_dotdir_denied(".sparrow", &[], &[]));
     }


### PR DESCRIPTION
This folder may also contain sensitive data. If `.mozilla` is deemed too sensitive, by that same definition `.thunderbird` should be blacklisted as well.