### PR TITLE
Add kiro-cli sandbox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Pass `--private-home` or set `private_home = true` to skip this automatic dotdir
 - `.gnupg`, `.aws`, `.ssh`, `.mozilla`, `.thunderbird`, `.basilisk-dev`, `.sparrow`
 
 **Mounted read-write (AI tools and build caches):**
-- `.gemini`, `.claude`, `.crush`, `.codex`, `.aider`, `.soulforge`, `.grok`, `.agents`, `.omp`, `.pi`, `.pi-lens`, `.config`, `.cargo`, `.cache`, `.docker`
+- `.gemini`, `.claude`, `.crush`, `.codex`, `.aider`, `.kiro`, `.soulforge`, `.grok`, `.agents`, `.omp`, `.pi`, `.pi-lens`, `.config`, `.cargo`, `.cache`, `.docker`
 
 **Everything else:** mounted read-only.
 
@@ -378,7 +378,7 @@ Pass `--private-home` or set `private_home = true` to skip this automatic dotdir
 
 **Local overrides (read-write):**
 - `~/.local/state`
-- `~/.local/share/{zoxide,crush,opencode,atuin,mise,yarn,flutter,kotlin,NuGet,pipx,ruby-advisory-db,uv}`
+- `~/.local/share/{zoxide,crush,kiro-cli,opencode,atuin,mise,yarn,flutter,kotlin,NuGet,pipx,ruby-advisory-db,uv}`
 
 ### Namespace isolation
 

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -398,6 +398,7 @@ const CACHE_DENY: &[&str] = &[
 const LOCAL_SHARE_RW: &[&str] = &[
     "zoxide",
     "crush",
+    "kiro-cli",
     "opencode",
     "soulforge",
     "atuin",

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -2915,6 +2915,26 @@ mod tests {
     }
 
     #[test]
+    fn local_share_kiro_cli_is_mounted_read_write() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir()
+            .join(format!("ai-jail-kiro-cli-home-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        let kiro_cli = home.join(".local/share/kiro-cli");
+        std::fs::create_dir_all(&kiro_cli).unwrap();
+
+        let _home = EnvVarGuard::set("HOME", &home);
+        let mounts = discover_local_overrides();
+
+        assert!(mounts.iter().any(|m| matches!(
+            m,
+            Mount::Bind { src, dest } if src == &kiro_cli && dest == &kiro_cli
+        )));
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
     fn format_dry_run_empty() {
         let args: Vec<String> = vec![];
         let output = format_dry_run_args(&args);

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -117,6 +117,7 @@ const DOTDIR_RW: &[&str] = &[
     ".crush",
     ".codex",
     ".aider",
+    ".kiro",
     ".soulforge",
     ".grok",
     ".agents",

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1110,6 +1110,7 @@ mod tests {
             ".crush",
             ".codex",
             ".aider",
+            ".kiro",
             ".soulforge",
             ".grok",
             ".agents",
@@ -1188,8 +1189,8 @@ mod tests {
     #[test]
     fn cannot_deny_rw_required_dirs() {
         let required = [
-            ".cargo", ".cache", ".config", ".claude", ".gemini", ".omp", ".pi",
-            ".pi-lens",
+            ".cargo", ".cache", ".config", ".claude", ".gemini", ".kiro",
+            ".omp", ".pi", ".pi-lens",
         ];
         for name in required {
             let extra = vec![name.to_string()];
@@ -1208,6 +1209,8 @@ mod tests {
         assert!(is_dotdir_rw(".cache"));
         assert!(is_dotdir_rw(".omp"));
         assert!(is_dotdir_rw("omp"));
+        assert!(is_dotdir_rw(".kiro"));
+        assert!(is_dotdir_rw("kiro"));
         assert!(is_dotdir_rw(".pi"));
         assert!(is_dotdir_rw("pi"));
         assert!(is_dotdir_rw(".pi-lens"));


### PR DESCRIPTION
 ### Problem

When running ai-jail  the application fails with:
Landlock: fully enforced
error: Read-only file system (os error 30)

 ### Root Cause

  Two directories are missing from the sandbox mount lists:

  - `~/.kiro` — not present in `DOTDIR_RW`, so it was either not mounted at  all (if it exists) or mounted read-only, preventing kiro-cli from  persisting configuration.
  - `~/.local/share/kiro-cli` — not present in `LOCAL_SHARE_RW`, so it was   excluded from the local-overrides read-write bind mounts.

  ### Solution

  Add the two directories to the appropriate allowlists so they are   bind-mounted read-write when they exist on the host, following the same  pattern already used for other AI tools (`.claude`, `.codex`, `.crush`,  `opencode`, etc.).

  ### Changes

  - `src/sandbox/mod.rs`: added `".kiro"` to `DOTDIR_RW` — causes  `discover_home_dotfiles()` to mount `~/.kiro` read-write.
  - `src/sandbox/bwrap.rs`: added `"kiro-cli"` to `LOCAL_SHARE_RW` — causes   `discover_local_overrides()` to mount ~/.local/share/kiro-cli`  read-write.

  ### Testing

  - `cargo fmt && cargo clippy -- -D warnings && cargo test` — all pass.
  - Manually verified kiro-cli runs correctly inside the sandbox after the
    change (both `~/.kiro` and `~/.local/share/kiro-cli` are accessible
    read-write).
