### PR TITLE
fix: resolve nix run build failure and make tests hermetic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,12 @@
           buildInputs = [
             rust
             formatter
+            pkgs.bubblewrap
           ];
+
+          shellHook = ''
+            export BWRAP_BIN="${pkgs.bubblewrap}/bin/bwrap"
+          '';
         };
       }
     );

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -2025,6 +2025,18 @@ fn git_worktree_mounts(
 }
 
 fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
+    extra_mounts_with_check(rw_maps, ro_maps, super::path_exists)
+}
+
+/// Inner implementation of [`extra_mounts`] that accepts an injectable
+/// path-existence predicate. This makes the logic unit-testable in hermetic
+/// environments (e.g. the Nix build sandbox) where host paths like `/usr`
+/// may not exist.
+fn extra_mounts_with_check(
+    rw_maps: &[PathBuf],
+    ro_maps: &[PathBuf],
+    path_exists: impl Fn(&Path) -> bool,
+) -> Vec<Mount> {
     let mut mounts = Vec::new();
 
     // Apply ro-maps first, then rw-maps on top. This lets a
@@ -2038,7 +2050,7 @@ fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
             );
             continue;
         }
-        if super::path_exists(path) {
+        if path_exists(path) {
             mounts.push(Mount::RoBind {
                 src: path.clone(),
                 dest: path.clone(),
@@ -2058,7 +2070,7 @@ fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
             );
             continue;
         }
-        if super::path_exists(path) {
+        if path_exists(path) {
             mounts.push(Mount::Bind {
                 src: path.clone(),
                 dest: path.clone(),
@@ -2867,12 +2879,13 @@ mod tests {
 
     #[test]
     fn extra_mounts_rw_child_overrides_ro_parent() {
-        // Use /usr and /usr/bin which always exist. The order
-        // of returned mounts must be: ro first, rw after — so a
-        // rw subdirectory can overlay its ro parent.
+        // Inject |_| true so the test is hermetic: it doesn't require
+        // /usr or /usr/bin to exist on the host (they won't in the Nix
+        // build sandbox). The ordering guarantee — ro first, rw after —
+        // is the invariant under test, not path existence.
         let ro = vec![PathBuf::from("/usr")];
         let rw = vec![PathBuf::from("/usr/bin")];
-        let mounts = extra_mounts(&rw, &ro);
+        let mounts = extra_mounts_with_check(&rw, &ro, |_| true);
         assert_eq!(mounts.len(), 2);
         match &mounts[0] {
             Mount::RoBind { src, .. } => {
@@ -2890,9 +2903,12 @@ mod tests {
 
     #[test]
     fn extra_mounts_refuses_root_maps() {
+        // Use |_| true so real host paths aren't required (hermetic in
+        // the Nix sandbox). The invariant under test is that "/" entries
+        // are filtered out regardless of existence.
         let ro = vec![PathBuf::from("/"), PathBuf::from("/usr")];
         let rw = vec![PathBuf::from("/"), PathBuf::from("/usr/bin")];
-        let mounts = extra_mounts(&rw, &ro);
+        let mounts = extra_mounts_with_check(&rw, &ro, |_| true);
 
         assert_eq!(mounts.len(), 2);
         assert!(mounts.iter().all(|m| match m {


### PR DESCRIPTION
Fixes a build failure when running nix run .

The issue was that two unit tests in src/sandbox/bwrap.rs were hardcoded to check if /usr and /usr/bin exist on the host. This breaks the build in hermetic environments like Nix sandboxes, Guix, Bazel RBE, or distroless Docker containers where those paths don't exist.

To fix this, I split extra_mounts so we can inject a path-existence checker during tests, making them fully hermetic. I also added bubblewrap and BWRAP_BIN to the Nix devShell so integration tests pass out of the box when running nix develop -c cargo test.