### PR TITLE
Fix clippy -D warnings on macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -383,7 +383,11 @@ fn run() -> Result<i32, String> {
         code
     };
 
-    // Guard is dropped here, cleaning up any temp files
+    // Guard is dropped here, cleaning up any temp files. On macOS the
+    // guard is a unit struct (no temp files to clean), so the explicit
+    // drop is a no-op there; clippy's drop_non_drop only fires on that
+    // platform. The drop stays meaningful on Linux (RAII temp files).
+    #[cfg_attr(target_os = "macos", allow(clippy::drop_non_drop))]
     drop(guard);
 
     Ok(exit_code)

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -454,10 +454,10 @@ fn macos_writable_paths(
         }
     }
 
-    if let Some(dir) = &config.claude_dir {
-        if super::path_exists(dir) {
-            paths.push(dir.clone());
-        }
+    if let Some(dir) = &config.claude_dir
+        && super::path_exists(dir)
+    {
+        paths.push(dir.clone());
     }
 
     paths.push(PathBuf::from("/tmp"));
@@ -570,10 +570,8 @@ fn macos_lockdown_read_paths(
     let browser_mode = config.browser_profile().is_some();
     let private_home = config.private_home_enabled();
 
-    if browser_mode {
-        if let Some(state) = super::browser_state_dir(config) {
-            push_unique(canonicalize_or_keep(&state));
-        }
+    if browser_mode && let Some(state) = super::browser_state_dir(config) {
+        push_unique(canonicalize_or_keep(&state));
     }
 
     if !private_home {
@@ -674,8 +672,10 @@ mod tests {
 
     #[test]
     fn sbpl_profile_lockdown_disables_network_and_writes() {
-        let mut config = Config::default();
-        config.lockdown = Some(true);
+        let config = Config {
+            lockdown: Some(true),
+            ..Config::default()
+        };
         let project = PathBuf::from("/tmp/test-project");
         let profile = generate_sbpl_profile(&config, &project, false, true);
         assert!(!profile.contains("(allow network-outbound)"));


### PR DESCRIPTION
Fixes #75.

On macOS, `cargo clippy -- -D warnings` fails on a clean master. All four
warnings are in macOS-only code, which is why the Linux CI doesn't see them.

- main.rs: `drop(guard)` triggers `drop_non_drop` because the macOS
  `SandboxGuard` has no `Drop`. Added `#[cfg_attr(target_os = "macos",
  allow(clippy::drop_non_drop))]` — the drop stays meaningful on Linux
  (temp file cleanup) and quiet on macOS.
- seatbelt.rs: collapsed two nested if-lets into `&& let` chains, matching
  the style already in config.rs.
- seatbelt.rs (test): swapped a `Config::default()` + reassignment for
  struct-init, like the neighbouring tests.

No behavior change. On Linux the cfg_attr expands to nothing, so that build
is untouched.

Checked on macOS:

    cargo fmt --check
    cargo clippy -- -D warnings
    cargo clippy --all-targets -- -D warnings
    cargo test   # 380 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
