### PR TITLE
feat: Add alternate destinations for --map and --rw-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,8 +453,8 @@ If no command is given and no `.ai-jail` config exists, defaults to `bash`.
 
 | Flag | Description |
 |------|-------------|
-| `--rw-map <PATH>` | Mount PATH read-write (repeatable). Relative paths and `..` are resolved against the project directory, so `--rw-map ../sister-project` works from a project root. Mapping `/` is refused; map explicit subpaths instead. |
-| `--map <PATH>` | Mount PATH read-only (repeatable). Same path resolution as `--rw-map`. Works on paths **inside** the writable project too — `--map .git` keeps `.git` visible but read-only (enforced by mount ordering on Linux and a write-deny rule on macOS). Mapping `/` is refused; map explicit subpaths instead. |
+| `--rw-map <PATH\|SOURCE:DEST>` | Mount a path read-write, optionally at a different destination (repeatable). See [Map destinations](#map-destinations). |
+| `--map <PATH\|SOURCE:DEST>` | Mount a path read-only, optionally at a different destination (repeatable). Works on paths **inside** the writable project too — `--map .git` keeps `.git` visible but read-only. See [Map destinations](#map-destinations). |
 | `--overlay-map <PATH>` | Mount PATH **copy-on-write** (repeatable). The agent sees PATH read-write, but writes land on a side layer under `<project>/.ai-jail-overlays/` while PATH itself is never modified — so you can diff and selectively promote changes afterwards. Opt-in only. Linux/bwrap only; degrades to **read-only** (with a warning) on macOS, and is disabled under `--lockdown` / browser mode. See [Overlay maps](#overlay-maps). |
 | `--hide-dotdir <NAME>` | Never bind-mount the named home dotdir into the sandbox (e.g. `.my_secrets`). Leading dot is optional. Repeatable. Cannot hide dotdirs required for tool operation (`.cargo`, `.config`, `.cache`, etc.) — those emit a warning and stay visible. |
 | `--mask <PATH\|GLOB>` | Replace `PATH` or glob matches inside the sandbox with an empty file (or empty tmpfs if the path is a directory). Relative paths resolve against the project directory. Repeatable. Supports `*`, `?`, `[a-z]`, and recursive `**`; quote glob masks in your shell. Useful for hiding sensitive files like `.env`, `**/*.env`, `credentials.json` from AI agents while keeping the rest of the project accessible. Missing paths/unmatched globs are skipped with a warning. |
@@ -489,6 +489,30 @@ If no command is given and no `.ai-jail` config exists, defaults to `bash`.
 | `-h`, `--help` | Show help |
 | `-V`, `--version` | Show version |
 
+### Map destinations
+
+`--map` and `--rw-map` accept either `PATH` or `SOURCE:DESTINATION`.
+`PATH` retains the existing same-path behavior: the host path appears at the
+same location inside the sandbox. `SOURCE:DESTINATION` mounts the host source
+at a different sandbox destination. The same syntax applies to the TOML
+`ro_maps` and `rw_maps` fields.
+
+The first colon always separates source from destination; any remaining
+colons belong to the destination. A source path containing a literal colon
+therefore cannot be represented with these options. This is an accepted
+syntax tradeoff.
+
+Both sides independently expand `~`, and relative paths plus `..` are resolved
+against the project directory. Mapping either the source or destination `/`
+is refused. Sources and destinations must be valid UTF-8. Malformed entries,
+non-UTF-8 paths, and entries whose source path is missing produce a warning
+and are skipped.
+
+Alternate destinations require Linux with bubblewrap. On macOS they cause a
+fatal error because `sandbox-exec` cannot remap paths. Same-path maps continue
+to work on macOS. `--overlay-map` does not support alternate destination
+syntax.
+
 ### Examples
 
 ```bash
@@ -497,6 +521,12 @@ ai-jail --rw-map ~/Projects/shared-lib claude
 
 # Read-only access to reference data
 ai-jail --map /opt/datasets claude
+
+# Expose a dedicated SSH directory as ~/.ssh inside the sandbox
+ai-jail --map ~/.ssh/ai-jail:~/.ssh claude
+
+# Mount project-relative data read-write at project-relative vendor/data
+ai-jail --rw-map data:vendor/data claude
 
 # Keep .git visible but read-only inside the writable project
 # (protects history and hooks from the agent)
@@ -612,7 +642,7 @@ Created in the project directory on first run. Example:
 
 command = ["claude"]
 rw_maps = ["/home/user/Projects/shared-lib"]
-ro_maps = []
+ro_maps = ["~/.ssh/ai-jail:~/.ssh"]
 mask = [".env", ".env.local", "**/*.env"]
 no_gpu = true
 ssh = true
@@ -625,7 +655,8 @@ lockdown = true
 When CLI flags and an existing config are both present:
 
 - `command`: CLI replaces config for the current run, but a CLI-passed command is **not** auto-persisted when the project already has a stored command — so `ai-jail codex` after `ai-jail claude` runs codex for that session without rewriting `.ai-jail`'s stored default. Use `ai-jail --init <command>` to explicitly change the stored command. First-run bootstrap (no stored command yet) still persists the CLI command as the new default.
-- `rw_maps` / `ro_maps` / `mask` / `deny_paths`: CLI values are appended (duplicates removed). Paths starting with `~/` or exactly `~` are expanded against `$HOME` at merge time, so you can write `ro_maps = ["~/.bashrc"]` in a config file. Relative paths in `rw_maps` / `ro_maps` (including `../sibling` style) are resolved against the project directory before being passed to the sandbox. Relative `mask` / `deny_paths` entries resolve against the project directory when the sandbox policy is built; glob masks/denies are expanded at that same point so committed configs can keep portable patterns.
+- `rw_maps` / `ro_maps`: CLI values are appended (duplicates removed). Each entry accepts `PATH` for a same-path map or `SOURCE:DESTINATION`; complete encoded entries are deduplicated. Both sides independently expand `~` against `$HOME` and resolve relative paths and `..` against the project directory. Alternate destinations require Linux/bubblewrap and fail on macOS.
+- `mask` / `deny_paths`: CLI values are appended (duplicates removed). Relative entries resolve against the project directory when the sandbox policy is built; glob masks/denies are expanded at that same point so committed configs can keep portable patterns.
 - Boolean flags: CLI overrides config (`--no-gpu` sets `no_gpu = true`)
 - `--save-config` / `--no-save-config` override `no_save_config`
 - Project config is updated in normal mode when config saving is enabled; inherited values from `$HOME/.ai-jail` are used at runtime but are not copied into the project `.ai-jail`. Lockdown skips auto-save.
@@ -649,8 +680,8 @@ The command key is selected from the first available command name: CLI command, 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `command` | string array | `["bash"]` | Default command to run inside sandbox. Set by first run or by `--init`; not overwritten when a different command is passed on the CLI. |
-| `rw_maps` | path array | `[]` | Extra read-write mounts. `/` is refused; map explicit subpaths instead. |
-| `ro_maps` | path array | `[]` | Extra read-only mounts. `/` is refused; map explicit subpaths instead. |
+| `rw_maps` | path array | `[]` | Extra read-write mounts using `PATH` or `SOURCE:DESTINATION`. Alternate destinations require Linux/bwrap. Source or destination `/` is refused. |
+| `ro_maps` | path array | `[]` | Extra read-only mounts using `PATH` or `SOURCE:DESTINATION`. Alternate destinations require Linux/bwrap. Source or destination `/` is refused. |
 | `overlay_maps` | path array | `[]` | Extra copy-on-write overlay mounts (see [Overlay maps](#overlay-maps)). Writes go to a side layer; the source stays untouched. Linux/bwrap only. |
 | `hide_dotdirs` | string array | `[]` | Extra home dotdirs to deny (e.g. `[".my_secrets"]`). Leading dot optional. Built-in deny list (`.ssh`, `.gnupg`, `.aws`, `.mozilla`, `.thunderbird`) always applies. |
 | `mask` | path array | `[]` | Paths or glob patterns to replace with empty files/tmpfs (e.g. `[".env", "**/*.env", "secrets.json"]`). Relative paths resolve against the project directory. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,8 +15,10 @@ COMMANDS (positional):
     Any other string                       Passed through as the command
 
 OPTIONS:
-    --rw-map <PATH>                Mount PATH read-write inside sandbox (repeatable)
-    --map <PATH>                   Mount PATH read-only inside sandbox (repeatable)
+    --rw-map <PATH|SOURCE:DEST>    Mount read-write, optionally at DEST
+                                   (repeatable)
+    --map <PATH|SOURCE:DEST>       Mount read-only, optionally at DEST
+                                   (repeatable)
     --overlay-map <PATH>           Mount PATH copy-on-write: writes go to a side
                                    layer, PATH itself stays untouched so you can
                                    diff/promote later (repeatable; Linux/bwrap
@@ -101,6 +103,10 @@ pub struct CliArgs {
     /// Internal: apply Landlock and exec remaining command.
     /// Used as a wrapper inside the bwrap sandbox.
     pub landlock_exec: bool,
+    /// Internal: opaque read-write mount destinations for Landlock.
+    pub landlock_rw_paths: Vec<PathBuf>,
+    /// Internal: opaque read-only mount destinations for Landlock.
+    pub landlock_ro_paths: Vec<PathBuf>,
 }
 
 pub fn parse() -> Result<CliArgs, String> {
@@ -266,6 +272,16 @@ pub fn parse_from(mut parser: lexopt::Parser) -> Result<CliArgs, String> {
                 args.status_bar = Some(false);
             }
             Long("landlock-exec") => args.landlock_exec = true,
+            Long("landlock-rw-path") => {
+                let val: PathBuf =
+                    parser.value().map_err(|e| e.to_string())?.into();
+                args.landlock_rw_paths.push(val);
+            }
+            Long("landlock-ro-path") => {
+                let val: PathBuf =
+                    parser.value().map_err(|e| e.to_string())?.into();
+                args.landlock_ro_paths.push(val);
+            }
             Long("clean") => args.clean = true,
             Long("dry-run") => args.dry_run = true,
             Long("init") => args.init = true,
@@ -698,6 +714,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_maps_with_alternate_destinations() {
+        let args = parse_test(&[
+            "--map",
+            "~/.ssh/ai-jail:~/.ssh",
+            "--rw-map",
+            "data:vendor/data",
+            "bash",
+        ])
+        .unwrap();
+
+        assert_eq!(args.ro_maps, vec![PathBuf::from("~/.ssh/ai-jail:~/.ssh")]);
+        assert_eq!(args.rw_maps, vec![PathBuf::from("data:vendor/data")]);
+    }
+
+    #[test]
     fn parse_multiple_maps() {
         let args = parse_test(&[
             "--rw-map", "/tmp/a", "--rw-map", "/tmp/b", "--map", "/opt/c",
@@ -870,6 +901,27 @@ mod tests {
         assert_eq!(args.lockdown, Some(true));
         assert!(args.verbose);
         assert_eq!(args.command, vec!["bash"]);
+    }
+
+    #[test]
+    fn parse_internal_landlock_paths_are_opaque() {
+        let rw = PathBuf::from("/jail/name:/etc");
+        let ro = PathBuf::from("/jail/ro:name");
+        let args = parse_test(&[
+            "--landlock-rw-path",
+            rw.to_str().unwrap(),
+            "--landlock-ro-path",
+            ro.to_str().unwrap(),
+            "--landlock-exec",
+            "--",
+            "bash",
+        ])
+        .unwrap();
+
+        assert_eq!(args.landlock_rw_paths, vec![rw]);
+        assert_eq!(args.landlock_ro_paths, vec![ro]);
+        assert!(!HELP.contains("--landlock-rw-path"));
+        assert!(!HELP.contains("--landlock-ro-path"));
     }
 
     // ── Exec mode ──────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use crate::cli::CliArgs;
 use crate::output;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 const CONFIG_FILE: &str = ".ai-jail";
@@ -26,6 +28,99 @@ pub fn parse_browser_profile_spec(value: &str) -> Option<BrowserProfile> {
         "hard" | "isolated" | "ephemeral" => Some(BrowserProfile::Hard),
         "soft" | "persistent" | "survivable" => Some(BrowserProfile::Soft),
         _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct MapSpec {
+    pub source: PathBuf,
+    pub destination: PathBuf,
+}
+
+#[allow(dead_code)]
+impl MapSpec {
+    pub fn parse(value: &Path) -> Result<Self, String> {
+        let bytes = value.as_os_str().as_bytes();
+        let Some(separator) = bytes.iter().position(|byte| *byte == b':')
+        else {
+            if bytes.is_empty() {
+                return Err("map has empty source and destination".into());
+            }
+            return Ok(Self {
+                source: value.to_path_buf(),
+                destination: value.to_path_buf(),
+            });
+        };
+
+        let source = &bytes[..separator];
+        let destination = &bytes[separator + 1..];
+        if source.is_empty() {
+            return Err("map has empty source".into());
+        }
+        if destination.is_empty() {
+            return Err("map has empty destination".into());
+        }
+
+        Ok(Self {
+            source: PathBuf::from(OsString::from_vec(source.to_vec())),
+            destination: PathBuf::from(OsString::from_vec(
+                destination.to_vec(),
+            )),
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.source.as_os_str().is_empty() {
+            return Err("map has empty source".into());
+        }
+        if self.destination.as_os_str().is_empty() {
+            return Err("map has empty destination".into());
+        }
+        if self.source.to_str().is_none() {
+            return Err("map source must be valid UTF-8".into());
+        }
+        if self.destination.to_str().is_none() {
+            return Err("map destination must be valid UTF-8".into());
+        }
+        if self.source == Path::new("/") {
+            return Err("map cannot use root source".into());
+        }
+        if self.destination == Path::new("/") {
+            return Err("map cannot use root destination".into());
+        }
+        Ok(())
+    }
+
+    pub fn is_alternate(&self) -> bool {
+        self.source != self.destination
+    }
+
+    pub fn encode(&self) -> PathBuf {
+        if !self.is_alternate() {
+            return self.source.clone();
+        }
+
+        let mut encoded = self.source.as_os_str().as_bytes().to_vec();
+        encoded.push(b':');
+        encoded.extend_from_slice(self.destination.as_os_str().as_bytes());
+        PathBuf::from(OsString::from_vec(encoded))
+    }
+}
+
+fn transform_map_specs(
+    paths: &mut [PathBuf],
+    mut transform: impl FnMut(PathBuf) -> PathBuf,
+) {
+    for path in paths {
+        let Ok(spec) = MapSpec::parse(path) else {
+            continue;
+        };
+        *path = MapSpec {
+            source: transform(spec.source),
+            destination: transform(spec.destination),
+        }
+        .encode();
     }
 }
 
@@ -447,8 +542,8 @@ fn save_to_path(path: &Path, config: &Config) {
 }
 
 fn collapse_tilde_config(config: &mut Config) {
-    collapse_tilde_vec(&mut config.rw_maps);
-    collapse_tilde_vec(&mut config.ro_maps);
+    transform_map_specs(&mut config.rw_maps, |path| collapse_tilde(&path));
+    transform_map_specs(&mut config.ro_maps, |path| collapse_tilde(&path));
     collapse_tilde_vec(&mut config.overlay_maps);
     collapse_tilde_vec(&mut config.mask);
     collapse_tilde_vec(&mut config.deny_paths);
@@ -572,8 +667,8 @@ fn absolutize_vec(paths: &mut [PathBuf], base: &Path) {
 /// a relative path which it silently rejects, leaving the mount
 /// invisible inside the sandbox (issue #54).
 pub fn absolutize_user_paths(config: &mut Config, cwd: &Path) {
-    absolutize_vec(&mut config.rw_maps, cwd);
-    absolutize_vec(&mut config.ro_maps, cwd);
+    transform_map_specs(&mut config.rw_maps, |path| to_absolute(path, cwd));
+    transform_map_specs(&mut config.ro_maps, |path| to_absolute(path, cwd));
     absolutize_vec(&mut config.overlay_maps, cwd);
 }
 
@@ -701,8 +796,8 @@ pub fn merge(cli: &CliArgs, existing: Config) -> Config {
     // Config files are TOML (no shell expansion); CLI args are
     // shell-expanded already but harmless to re-run. Only leading
     // tilde is recognized; `~user` is left alone.
-    expand_tilde_vec(&mut config.rw_maps);
-    expand_tilde_vec(&mut config.ro_maps);
+    transform_map_specs(&mut config.rw_maps, expand_tilde);
+    transform_map_specs(&mut config.ro_maps, expand_tilde);
     expand_tilde_vec(&mut config.overlay_maps);
     expand_tilde_vec(&mut config.mask);
     expand_tilde_vec(&mut config.deny_paths);
@@ -895,6 +990,104 @@ mod tests {
     // ── Parsing tests ──────────────────────────────────────────
 
     #[test]
+    fn map_spec_parses_same_path_and_alternate_destination() {
+        let same = MapSpec::parse(Path::new("/opt/data")).unwrap();
+        assert_eq!(same.source, PathBuf::from("/opt/data"));
+        assert_eq!(same.destination, PathBuf::from("/opt/data"));
+        assert!(!same.is_alternate());
+
+        let alternate =
+            MapSpec::parse(Path::new("/host/data:/jail/data:copy")).unwrap();
+        assert_eq!(alternate.source, PathBuf::from("/host/data"));
+        assert_eq!(alternate.destination, PathBuf::from("/jail/data:copy"));
+        assert!(alternate.is_alternate());
+    }
+
+    #[test]
+    fn map_spec_rejects_empty_components_and_root() {
+        let error = MapSpec::parse(Path::new(":/jail")).unwrap_err();
+        assert!(error.contains("empty source"));
+
+        let error = MapSpec::parse(Path::new("/host:")).unwrap_err();
+        assert!(error.contains("empty destination"));
+
+        let root_source = MapSpec::parse(Path::new("/:/jail")).unwrap();
+        let error = root_source.validate().unwrap_err();
+        assert!(error.contains("root source"));
+
+        let root_destination = MapSpec::parse(Path::new("/host:/")).unwrap();
+        let error = root_destination.validate().unwrap_err();
+        assert!(error.contains("root destination"));
+    }
+
+    #[test]
+    fn map_spec_validate_rejects_empty_components() {
+        let empty_source = MapSpec {
+            source: PathBuf::new(),
+            destination: PathBuf::from("/jail"),
+        };
+        let error = empty_source.validate().unwrap_err();
+        assert!(error.contains("empty source"));
+
+        let empty_destination = MapSpec {
+            source: PathBuf::from("/host"),
+            destination: PathBuf::new(),
+        };
+        let error = empty_destination.validate().unwrap_err();
+        assert!(error.contains("empty destination"));
+    }
+
+    #[test]
+    fn map_spec_encoding_keeps_legacy_shape() {
+        let same = MapSpec {
+            source: PathBuf::from("/opt/data"),
+            destination: PathBuf::from("/opt/data"),
+        };
+        assert_eq!(same.encode(), PathBuf::from("/opt/data"));
+
+        let alternate = MapSpec {
+            source: PathBuf::from("/host/data"),
+            destination: PathBuf::from("/jail/data"),
+        };
+        assert_eq!(alternate.encode(), PathBuf::from("/host/data:/jail/data"));
+    }
+
+    #[test]
+    fn map_spec_preserves_but_rejects_non_utf8_bytes() {
+        fn assert_rejected(
+            encoded_bytes: &[u8],
+            source: &[u8],
+            destination: &[u8],
+            component: &str,
+        ) {
+            let encoded =
+                PathBuf::from(OsString::from_vec(encoded_bytes.to_vec()));
+            let map = MapSpec::parse(&encoded).unwrap();
+
+            assert_eq!(map.source.as_os_str().as_bytes(), source);
+            assert_eq!(map.destination.as_os_str().as_bytes(), destination);
+            assert_eq!(map.encode().as_os_str().as_bytes(), encoded_bytes);
+
+            let error = map.validate().unwrap_err();
+            assert!(error.contains(component), "unexpected error: {error}");
+            assert!(error.contains("UTF-8"), "unexpected error: {error}");
+        }
+
+        assert_rejected(
+            b"/host/\xff/data:/jail/data",
+            b"/host/\xff/data",
+            b"/jail/data",
+            "source",
+        );
+        assert_rejected(
+            b"/host/data:/jail/\xfe/data:copy",
+            b"/host/data",
+            b"/jail/\xfe/data:copy",
+            "destination",
+        );
+    }
+
+    #[test]
     fn parse_minimal_config() {
         let cfg = parse_toml("").unwrap();
         assert!(cfg.command.is_empty());
@@ -967,6 +1160,19 @@ lockdown = true
 
     // ── Backward compatibility regression tests ────────────────
     // NEVER DELETE THESE. Add new ones when the format changes.
+
+    #[test]
+    fn regression_pre_alternate_destination_map_format() {
+        let toml = r#"
+command = ["claude"]
+rw_maps = ["/tmp/shared"]
+ro_maps = ["~/.ssh"]
+"#;
+        let cfg = parse_toml(toml).unwrap();
+
+        assert_eq!(cfg.rw_maps, vec![PathBuf::from("/tmp/shared")]);
+        assert_eq!(cfg.ro_maps, vec![PathBuf::from("~/.ssh")]);
+    }
 
     #[test]
     fn regression_v0_1_0_config_format() {
@@ -1424,6 +1630,31 @@ no_gpu = true
         assert_eq!(
             merged.ro_maps,
             vec![PathBuf::from("/opt/x"), PathBuf::from("/opt/y")]
+        );
+    }
+
+    #[test]
+    fn merge_deduplicates_complete_map_specifications() {
+        let existing = Config {
+            rw_maps: vec![PathBuf::from("/host/data:/jail/one")],
+            ..Config::default()
+        };
+        let cli = CliArgs {
+            rw_maps: vec![
+                PathBuf::from("/host/data:/jail/one"),
+                PathBuf::from("/host/data:/jail/two"),
+            ],
+            ..CliArgs::default()
+        };
+
+        let merged = merge(&cli, existing);
+
+        assert_eq!(
+            merged.rw_maps,
+            vec![
+                PathBuf::from("/host/data:/jail/one"),
+                PathBuf::from("/host/data:/jail/two"),
+            ]
         );
     }
 
@@ -2822,6 +3053,23 @@ hide_dotdirs = [".my_secrets"]
         assert_eq!(merged.mask, vec![PathBuf::from("/home/user/secret.env")]);
     }
 
+    #[test]
+    fn merge_expands_tilde_on_both_map_sides() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let _home = EnvVarGuard::set("HOME", "/home/user");
+        let existing = Config {
+            ro_maps: vec![PathBuf::from("~/.ssh/ai-jail:~/.ssh")],
+            ..Config::default()
+        };
+
+        let merged = merge(&CliArgs::default(), existing);
+
+        assert_eq!(
+            merged.ro_maps,
+            vec![PathBuf::from("/home/user/.ssh/ai-jail:/home/user/.ssh")]
+        );
+    }
+
     // ── Relative-path resolution tests (issue #54) ────────────
 
     #[test]
@@ -2950,6 +3198,37 @@ hide_dotdirs = [".my_secrets"]
         assert_eq!(config.ro_maps, vec![PathBuf::from("/opt/data")]);
     }
 
+    #[test]
+    fn absolutize_user_paths_resolves_both_map_sides() {
+        let mut config = Config {
+            rw_maps: vec![PathBuf::from("../shared:vendor/shared")],
+            ..Config::default()
+        };
+
+        absolutize_user_paths(&mut config, Path::new("/work/project"));
+
+        assert_eq!(
+            config.rw_maps,
+            vec![PathBuf::from("/work/shared:/work/project/vendor/shared")]
+        );
+    }
+
+    #[test]
+    fn alternate_map_absolutization_is_idempotent() {
+        let mut config = Config {
+            rw_maps: vec![PathBuf::from("/host/data:/jail/data")],
+            ..Config::default()
+        };
+
+        absolutize_user_paths(&mut config, Path::new("/first"));
+        absolutize_user_paths(&mut config, Path::new("/second"));
+
+        assert_eq!(
+            config.rw_maps,
+            vec![PathBuf::from("/host/data:/jail/data")]
+        );
+    }
+
     // ── Tilde collapse tests (issue #52) ──────────────────────
 
     #[test]
@@ -3016,7 +3295,10 @@ hide_dotdirs = [".my_secrets"]
         let cfg = Config {
             command: vec!["claude".into()],
             // These are expanded as if they had passed through merge().
-            rw_maps: vec![PathBuf::from("/home/user/.claude")],
+            rw_maps: vec![
+                PathBuf::from("/home/user/.claude"),
+                PathBuf::from("/home/user/.ssh/ai-jail:/home/user/.ssh"),
+            ],
             ro_maps: vec![PathBuf::from("/home/user/.bashrc")],
             mask: vec![PathBuf::from("/home/user/secret.env")],
             claude_dir: Some(PathBuf::from("/home/user/.claude-work")),
@@ -3029,6 +3311,10 @@ hide_dotdirs = [".my_secrets"]
             written.contains("\"~/.claude\""),
             "expected ~/.claude in TOML, got:\n{written}"
         );
+        assert!(
+            written.contains("\"~/.ssh/ai-jail:~/.ssh\""),
+            "alternate map not collapsed: {written}"
+        );
         assert!(written.contains("\"~/.bashrc\""), "rw_maps not collapsed");
         assert!(written.contains("\"~/secret.env\""), "mask not collapsed");
         assert!(
@@ -3039,7 +3325,13 @@ hide_dotdirs = [".my_secrets"]
         // should yield the same absolute paths we started with.
         let parsed = parse_toml(&written).unwrap();
         let merged = merge(&CliArgs::default(), parsed);
-        assert_eq!(merged.rw_maps, vec![PathBuf::from("/home/user/.claude")]);
+        assert_eq!(
+            merged.rw_maps,
+            vec![
+                PathBuf::from("/home/user/.claude"),
+                PathBuf::from("/home/user/.ssh/ai-jail:/home/user/.ssh"),
+            ]
+        );
         assert_eq!(merged.ro_maps, vec![PathBuf::from("/home/user/.bashrc")]);
         assert_eq!(merged.mask, vec![PathBuf::from("/home/user/secret.env")]);
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,14 +109,22 @@ fn run_landlock_exec(cli: &cli::CliArgs) -> Result<i32, String> {
     let project_dir = std::env::current_dir()
         .map_err(|e| format!("Cannot determine current directory: {e}"))?;
 
-    // Use the fully resolved outer policy forwarded via internal args.
+    // Use the fully resolved non-map policy forwarded via internal args.
+    // Mounted destinations remain separate opaque paths below.
     let mut config = config::merge(cli, config::Config::default());
     // Idempotent: parent absolutized before serializing wrapper args,
     // but re-running guarantees no relative path reaches landlock.
     config::absolutize_user_paths(&mut config, &project_dir);
 
-    // Apply Landlock inside the sandbox (after bwrap namespace setup)
-    sandbox::apply_landlock(&config, &project_dir, cli.verbose)?;
+    // Apply Landlock inside the sandbox (after bwrap namespace setup).
+    // Hidden path flags preserve destinations atomically, including ':'.
+    sandbox::apply_landlock(
+        &config,
+        &project_dir,
+        &cli.landlock_ro_paths,
+        &cli.landlock_rw_paths,
+        cli.verbose,
+    )?;
 
     // Apply seccomp filter after Landlock (reduces kernel syscall
     // surface). Must happen before exec so the user command inherits

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, MapSpec};
 use crate::output;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -135,6 +135,28 @@ impl Mount {
             }
         }
     }
+}
+
+fn mounted_map_args<'a>(
+    mounts: impl IntoIterator<Item = &'a Mount>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+    for mount in mounts {
+        match mount {
+            Mount::RoBind { dest, .. } => {
+                // Internal flags carry mounted destinations opaquely; public
+                // map flags would reinterpret ':' as source/destination syntax.
+                args.push("--landlock-ro-path".into());
+                args.push(dest.display().to_string());
+            }
+            Mount::Bind { dest, .. } => {
+                args.push("--landlock-rw-path".into());
+                args.push(dest.display().to_string());
+            }
+            _ => {}
+        }
+    }
+    args
 }
 
 struct MountSet {
@@ -876,7 +898,11 @@ fn resolve_landlock_wrapper(
     }
 }
 
-fn landlock_wrapper_args(config: &Config, verbose: bool) -> Vec<String> {
+fn landlock_wrapper_args(
+    config: &Config,
+    map_args: &[String],
+    verbose: bool,
+) -> Vec<String> {
     let mut args = vec![
         LANDLOCK_WRAPPER_DEST.into(),
         "--landlock-exec".into(),
@@ -940,14 +966,7 @@ fn landlock_wrapper_args(config: &Config, verbose: bool) -> Vec<String> {
     }
 
     if config.browser_profile().is_none() {
-        for path in &config.rw_maps {
-            args.push("--rw-map".into());
-            args.push(path.display().to_string());
-        }
-        for path in &config.ro_maps {
-            args.push("--map".into());
-            args.push(path.display().to_string());
-        }
+        args.extend_from_slice(map_args);
     }
     for path in &config.mask {
         args.push("--mask".into());
@@ -979,6 +998,9 @@ pub fn build(
     let sources = MountSources::from_guard(guard);
     let mount_set =
         discover_mounts_full(config, project_dir, &sources, verbose);
+    let map_args = mounted_map_args(
+        mount_set.extra.iter().chain(mount_set.extra_inside.iter()),
+    );
     let lockdown = config.lockdown_enabled();
     let bwrap = bwrap_program_for_exec();
     let launch = super::build_launch_command(config);
@@ -1022,7 +1044,7 @@ pub fn build(
     cmd.arg("--");
 
     if wrapper.is_some() {
-        for arg in landlock_wrapper_args(config, verbose) {
+        for arg in landlock_wrapper_args(config, &map_args, verbose) {
             cmd.arg(arg);
         }
     }
@@ -1066,6 +1088,9 @@ fn build_dry_run_args_full(
     verbose: bool,
 ) -> Result<Vec<String>, String> {
     let mount_set = discover_mounts_full(config, project_dir, sources, verbose);
+    let map_args = mounted_map_args(
+        mount_set.extra.iter().chain(mount_set.extra_inside.iter()),
+    );
     let lockdown = config.lockdown_enabled();
     let launch = super::build_launch_command(config);
     let mut args: Vec<String> =
@@ -1092,7 +1117,7 @@ fn build_dry_run_args_full(
     args.push("--".into());
 
     if wrapper.is_some() {
-        args.extend(landlock_wrapper_args(config, verbose));
+        args.extend(landlock_wrapper_args(config, &map_args, verbose));
     }
 
     args.push(launch.program);
@@ -2131,6 +2156,27 @@ fn extra_mounts(rw_maps: &[PathBuf], ro_maps: &[PathBuf]) -> Vec<Mount> {
     extra_mounts_with_check(rw_maps, ro_maps, super::path_exists)
 }
 
+fn parse_extra_map(encoded: &Path, access: &str) -> Option<MapSpec> {
+    let spec = match MapSpec::parse(encoded) {
+        Ok(spec) => spec,
+        Err(reason) => {
+            output::warn(&format!(
+                "Invalid {access} map {}: {reason}; skipping.",
+                encoded.display()
+            ));
+            return None;
+        }
+    };
+    if let Err(reason) = spec.validate() {
+        output::warn(&format!(
+            "Invalid {access} map {}: {reason}; skipping.",
+            encoded.display()
+        ));
+        return None;
+    }
+    Some(spec)
+}
+
 /// Inner implementation of [`extra_mounts`] that accepts an injectable
 /// path-existence predicate. This makes the logic unit-testable in hermetic
 /// environments (e.g. the Nix build sandbox) where host paths like `/usr`
@@ -2146,42 +2192,36 @@ fn extra_mounts_with_check(
     // rw-subdirectory override an ro-parent, e.g.:
     //   --map ~/Projects --rw-map ~/Projects/ai-jail
     // makes ~/Projects read-only except the ai-jail subdir.
-    for path in ro_maps {
-        if path == Path::new("/") {
-            output::warn(
-                "Refusing to map / as an extra read-only mount; map explicit subpaths instead.",
-            );
+    for encoded in ro_maps {
+        let Some(spec) = parse_extra_map(encoded, "read-only") else {
             continue;
-        }
-        if path_exists(path) {
+        };
+        if path_exists(&spec.source) {
             mounts.push(Mount::RoBind {
-                src: path.clone(),
-                dest: path.clone(),
+                src: spec.source,
+                dest: spec.destination,
             });
         } else {
             output::warn(&format!(
                 "Path {} not found, skipping.",
-                path.display()
+                spec.source.display()
             ));
         }
     }
 
-    for path in rw_maps {
-        if path == Path::new("/") {
-            output::warn(
-                "Refusing to map / as an extra read-write mount; map explicit subpaths instead.",
-            );
+    for encoded in rw_maps {
+        let Some(spec) = parse_extra_map(encoded, "read-write") else {
             continue;
-        }
-        if path_exists(path) {
+        };
+        if path_exists(&spec.source) {
             mounts.push(Mount::Bind {
-                src: path.clone(),
-                dest: path.clone(),
+                src: spec.source,
+                dest: spec.destination,
             });
         } else {
             output::warn(&format!(
                 "Path {} not found, skipping.",
-                path.display()
+                spec.source.display()
             ));
         }
     }
@@ -2376,6 +2416,30 @@ mod tests {
             dest: "/tmp".into(),
         };
         assert_eq!(m.to_args(), vec!["--bind", "/tmp", "/tmp"]);
+    }
+
+    #[test]
+    fn mounted_map_args_forward_only_destinations() {
+        let mounts = [
+            Mount::RoBind {
+                src: "/host/ro".into(),
+                dest: "/jail/ro".into(),
+            },
+            Mount::Bind {
+                src: "/host/rw".into(),
+                dest: "/jail/rw".into(),
+            },
+        ];
+
+        assert_eq!(
+            mounted_map_args(&mounts),
+            vec![
+                "--landlock-ro-path",
+                "/jail/ro",
+                "--landlock-rw-path",
+                "/jail/rw",
+            ]
+        );
     }
 
     #[test]
@@ -3044,6 +3108,65 @@ mod tests {
     }
 
     #[test]
+    fn extra_mounts_use_alternate_source_and_destination() {
+        let ro = vec![PathBuf::from("/host/ro:/jail/ro")];
+        let rw = vec![PathBuf::from("/host/rw:/jail/rw")];
+
+        let mounts =
+            extra_mounts_with_check(&rw, &ro, |path| path.starts_with("/host"));
+
+        assert_eq!(mounts.len(), 2);
+        assert!(matches!(
+            &mounts[0],
+            Mount::RoBind { src, dest }
+                if src == Path::new("/host/ro")
+                    && dest == Path::new("/jail/ro")
+        ));
+        assert!(matches!(
+            &mounts[1],
+            Mount::Bind { src, dest }
+                if src == Path::new("/host/rw")
+                    && dest == Path::new("/jail/rw")
+        ));
+    }
+
+    #[test]
+    fn extra_mounts_check_source_and_reject_invalid_specs() {
+        let ro = vec![
+            PathBuf::from("/missing:/existing"),
+            PathBuf::from(":/invalid"),
+        ];
+        let rw = vec![PathBuf::from("/host:/")];
+        let checked = std::cell::RefCell::new(Vec::new());
+
+        let mounts = extra_mounts_with_check(&rw, &ro, |path| {
+            checked.borrow_mut().push(path.to_path_buf());
+            false
+        });
+
+        assert!(mounts.is_empty());
+        assert_eq!(checked.into_inner(), vec![PathBuf::from("/missing")]);
+    }
+
+    #[test]
+    fn extra_mounts_reject_non_utf8_before_source_check() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let ro = vec![PathBuf::from(std::ffi::OsString::from_vec(
+            b"/host/ro:/jail/\xff".to_vec(),
+        ))];
+        let checks = std::cell::Cell::new(0);
+
+        let mounts = extra_mounts_with_check(&[], &ro, |_| {
+            checks.set(checks.get() + 1);
+            true
+        });
+
+        assert!(mounts.is_empty());
+        assert_eq!(checks.get(), 0);
+    }
+
+    #[test]
     fn extra_mounts_refuses_root_maps() {
         // Use |_| true so real host paths aren't required (hermetic in
         // the Nix sandbox). The invariant under test is that "/" entries
@@ -3092,11 +3215,17 @@ mod tests {
     }
 
     /// Index of the first exact `[flag, src, dest]` triple in the args.
-    fn mount_arg_index(args: &[String], flag: &str, path: &Path) -> usize {
-        let p = path.display().to_string();
+    fn mount_arg_index(
+        args: &[String],
+        flag: &str,
+        src: &Path,
+        dest: &Path,
+    ) -> usize {
+        let src = src.display().to_string();
+        let dest = dest.display().to_string();
         args.windows(3)
-            .position(|w| w[0] == flag && w[1] == p && w[2] == p)
-            .unwrap_or_else(|| panic!("no `{flag} {p} {p}` in args"))
+            .position(|w| w[0] == flag && w[1] == src && w[2] == dest)
+            .unwrap_or_else(|| panic!("no `{flag} {src} {dest}` in args"))
     }
 
     /// Regression for #83: an `--map` path inside the project must be
@@ -3129,9 +3258,9 @@ mod tests {
         )
         .unwrap();
 
-        let project_at = mount_arg_index(&args, "--bind", &project);
-        let ro_map_at =
-            mount_arg_index(&args, "--ro-bind", &project.join(".git"));
+        let project_at = mount_arg_index(&args, "--bind", &project, &project);
+        let git = project.join(".git");
+        let ro_map_at = mount_arg_index(&args, "--ro-bind", &git, &git);
         assert!(
             ro_map_at > project_at,
             "in-project ro map (idx {ro_map_at}) must come after the \
@@ -3179,9 +3308,56 @@ mod tests {
         )
         .unwrap();
 
-        let project_at = mount_arg_index(&args, "--bind", &project);
-        let ro_map_at = mount_arg_index(&args, "--ro-bind", &outside);
+        let project_at = mount_arg_index(&args, "--bind", &project, &project);
+        let ro_map_at = mount_arg_index(&args, "--ro-bind", &outside, &outside);
         assert!(ro_map_at < project_at);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn alternate_destination_inside_project_binds_after_project() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir().join(format!(
+            "ai-jail-alternate-map-order-home-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        let project = home.join("project");
+        let source = home.join("shared-data");
+        let destination = project.join("vendor/shared");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+
+        let config = Config {
+            ro_maps: vec![PathBuf::from(format!(
+                "{}:{}",
+                source.display(),
+                destination.display()
+            ))],
+            ..minimal_test_config()
+        };
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_mount(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+
+        let project_at = mount_arg_index(&args, "--bind", &project, &project);
+        let ro_map_at =
+            mount_arg_index(&args, "--ro-bind", &source, &destination);
+        assert!(
+            ro_map_at > project_at,
+            "alternate in-project destination (idx {ro_map_at}) must come \
+             after the project bind (idx {project_at})"
+        );
 
         let _ = std::fs::remove_dir_all(&home);
     }
@@ -3215,7 +3391,7 @@ mod tests {
         )
         .unwrap();
 
-        let project_at = mount_arg_index(&args, "--bind", &project);
+        let project_at = mount_arg_index(&args, "--bind", &project, &project);
         let overlay_at = args
             .iter()
             .position(|a| a == "--overlay-src")
@@ -3994,13 +4170,117 @@ mod tests {
         config.lockdown = Some(true);
         config.allow_tcp_ports = vec![32000, 8080];
 
-        let wrapper_args = landlock_wrapper_args(&config, false);
+        let wrapper_args = landlock_wrapper_args(&config, &[], false);
         let port_args: Vec<_> = wrapper_args
             .windows(2)
             .filter(|w| w[0] == "--allow-tcp-port")
             .map(|w| w[1].clone())
             .collect();
         assert_eq!(port_args, vec!["32000", "8080"]);
+    }
+
+    #[test]
+    fn landlock_wrapper_forwards_only_successfully_mounted_destinations() {
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-landlock-wrapper-maps-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let project = root.join("project");
+        let source = root.join("source");
+        let destination = project.join("destination");
+        let missing_source = root.join("missing-source");
+        let missing_destination = project.join("missing-destination");
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+
+        let config = Config {
+            rw_maps: vec![
+                MapSpec {
+                    source: source.clone(),
+                    destination: destination.clone(),
+                }
+                .encode(),
+                MapSpec {
+                    source: missing_source.clone(),
+                    destination: missing_destination.clone(),
+                }
+                .encode(),
+            ],
+            ..minimal_test_config()
+        };
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_mount(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+        let separator = args.iter().position(|arg| arg == "--").unwrap();
+        let wrapper_args = &args[separator + 1..];
+
+        assert!(wrapper_args.windows(2).any(|args| {
+            args[0] == "--landlock-rw-path"
+                && args[1] == destination.display().to_string()
+        }));
+        assert!(!wrapper_args.contains(&source.display().to_string()));
+        assert!(!wrapper_args.contains(&missing_source.display().to_string()));
+        assert!(
+            !wrapper_args.contains(&missing_destination.display().to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn landlock_wrapper_keeps_colon_destination_opaque() {
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-landlock-wrapper-colon-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let project = root.join("project");
+        let source = root.join("source");
+        let destination = project.join("name:/etc");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+
+        let config = Config {
+            rw_maps: vec![
+                MapSpec {
+                    source,
+                    destination: destination.clone(),
+                }
+                .encode(),
+            ],
+            ..minimal_test_config()
+        };
+        let guard =
+            SandboxGuard::test_with_hosts(PathBuf::from("/tmp/test-hosts"));
+        let args = build_dry_run_args(
+            &config,
+            &project,
+            guard.hosts_mount(),
+            guard.resolv_mount(),
+            guard.empty_path(),
+            false,
+        )
+        .unwrap();
+        let separator = args.iter().position(|arg| arg == "--").unwrap();
+        let wrapper_args = &args[separator + 1..];
+
+        assert!(wrapper_args.windows(2).any(|args| {
+            args[0] == "--landlock-rw-path"
+                && args[1] == destination.display().to_string()
+        }));
+        assert!(!wrapper_args.contains(&"--rw-map".to_string()));
+        assert!(!wrapper_args.contains(&"--map".to_string()));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -4011,7 +4291,7 @@ mod tests {
         config.rw_maps = vec![PathBuf::from("/tmp/browser-rw")];
         config.ro_maps = vec![PathBuf::from("/tmp/browser-ro")];
 
-        let wrapper_args = landlock_wrapper_args(&config, false);
+        let wrapper_args = landlock_wrapper_args(&config, &[], false);
 
         assert!(!wrapper_args.contains(&"--rw-map".into()));
         assert!(!wrapper_args.contains(&"--map".into()));

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -43,6 +43,8 @@
 //    no Docker, no GPU, no display.
 
 use crate::config::Config;
+#[cfg(test)]
+use crate::config::MapSpec;
 use crate::output;
 use landlock::{
     ABI, Access, AccessFs, AccessNet, NetPort, Ruleset, RulesetAttr,
@@ -56,6 +58,8 @@ const ABI_NET: ABI = ABI::V4;
 pub fn apply(
     config: &Config,
     project_dir: &Path,
+    mounted_ro_paths: &[PathBuf],
+    mounted_rw_paths: &[PathBuf],
     verbose: bool,
 ) -> Result<(), String> {
     if !config.landlock_enabled() {
@@ -68,7 +72,13 @@ pub fn apply(
         return Ok(());
     }
 
-    let fs_result = match do_apply(config, project_dir, verbose) {
+    let fs_result = match do_apply(
+        config,
+        project_dir,
+        mounted_ro_paths,
+        mounted_rw_paths,
+        verbose,
+    ) {
         Ok(status) => match status {
             RulesetStatus::FullyEnforced => {
                 output::info("Landlock: fully enforced");
@@ -138,6 +148,8 @@ pub fn apply(
 fn do_apply(
     config: &Config,
     project_dir: &Path,
+    mounted_ro_paths: &[PathBuf],
+    mounted_rw_paths: &[PathBuf],
     verbose: bool,
 ) -> Result<RulesetStatus, landlock::RulesetError> {
     let access_all = AccessFs::from_all(ABI_VERSION);
@@ -146,7 +158,13 @@ fn do_apply(
     let (ro_paths, rw_paths) = if config.lockdown_enabled() {
         collect_lockdown_paths(config, project_dir, verbose)
     } else {
-        collect_normal_paths(config, project_dir, verbose)
+        collect_normal_paths_with_mounted_paths(
+            config,
+            project_dir,
+            mounted_ro_paths,
+            mounted_rw_paths,
+            verbose,
+        )
     };
 
     let status = Ruleset::default()
@@ -358,9 +376,44 @@ fn collect_lockdown_paths(
 /// two layers are complementary — Landlock prevents writes to
 /// ro-bind-mounted paths, bwrap prevents access to unmounted
 /// paths.
+#[cfg(test)]
 fn collect_normal_paths(
     config: &Config,
     project_dir: &Path,
+    verbose: bool,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let (mounted_ro_paths, mounted_rw_paths) =
+        if config.browser_profile().is_some() {
+            (Vec::new(), Vec::new())
+        } else {
+            let rw = config
+                .rw_maps
+                .iter()
+                .filter_map(|path| landlock_map_destination(path, "rw"))
+                .collect();
+            let ro = config
+                .ro_maps
+                .iter()
+                .filter_map(|path| landlock_map_destination(path, "ro"))
+                .collect();
+            (ro, rw)
+        };
+    collect_normal_paths_with_mounted_paths(
+        config,
+        project_dir,
+        &mounted_ro_paths,
+        &mounted_rw_paths,
+        verbose,
+    )
+}
+
+/// Collect normal-mode paths using destinations already mounted by bwrap.
+/// These paths are opaque and must never be reparsed as public map specs.
+fn collect_normal_paths_with_mounted_paths(
+    config: &Config,
+    project_dir: &Path,
+    mounted_ro_paths: &[PathBuf],
+    mounted_rw_paths: &[PathBuf],
     verbose: bool,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let home = super::home_dir();
@@ -575,33 +628,31 @@ fn collect_normal_paths(
     }
 
     // Extra user mounts: --rw-map and --ro-map from CLI/config.
-    // These extend the sandbox with user-specified paths. Missing
-    // paths are skipped with a warning (never crash on missing).
+    // These extend the sandbox with user-specified destinations.
+    // Missing paths are skipped with a warning (never crash on missing).
     if !browser_mode {
-        for p in &config.rw_maps {
-            if super::path_exists(p) {
-                rw.push(p.clone());
+        for destination in mounted_rw_paths {
+            if super::path_exists(destination) {
+                rw.push(destination.clone());
             } else {
                 output::warn(&format!(
                     "Landlock: rw map {} not found, skipping",
-                    p.display()
+                    destination.display()
                 ));
             }
         }
-        // NOTE: an ro map inside the project dir cannot be enforced by
-        // Landlock — access rights are unioned across rules with no
-        // deny semantics, so the project's read-write rule always wins
-        // for its subtree. Read-only enforcement for such paths comes
-        // from the bwrap mount layer, which binds them ro on top of the
-        // project mount (#83); the ro rule here still covers maps
-        // outside the project.
-        for p in &config.ro_maps {
-            if super::path_exists(p) {
-                ro.push(p.clone());
+        // NOTE: a read-only map destination inside the project dir cannot
+        // be enforced by Landlock — access rights are unioned across rules
+        // with no deny semantics, so the project's read-write rule always
+        // wins for its subtree. The bwrap read-only bind enforces it; this
+        // rule still covers destinations outside the project.
+        for destination in mounted_ro_paths {
+            if super::path_exists(destination) {
+                ro.push(destination.clone());
             } else {
                 output::warn(&format!(
                     "Landlock: ro map {} not found, skipping",
-                    p.display()
+                    destination.display()
                 ));
             }
         }
@@ -620,7 +671,8 @@ fn collect_normal_paths(
                 ));
             }
         }
-        if verbose && (!config.rw_maps.is_empty() || !config.ro_maps.is_empty())
+        if verbose
+            && (!mounted_rw_paths.is_empty() || !mounted_ro_paths.is_empty())
         {
             output::verbose("Landlock: extra maps");
         }
@@ -717,6 +769,28 @@ fn collect_normal_paths(
     }
 
     (ro, rw)
+}
+
+#[cfg(test)]
+fn landlock_map_destination(encoded: &Path, access: &str) -> Option<PathBuf> {
+    let spec = match MapSpec::parse(encoded) {
+        Ok(spec) => spec,
+        Err(reason) => {
+            output::warn(&format!(
+                "Landlock: invalid {access} map {}: {reason}; skipping",
+                encoded.display()
+            ));
+            return None;
+        }
+    };
+    if let Err(reason) = spec.validate() {
+        output::warn(&format!(
+            "Landlock: invalid {access} map {}: {reason}; skipping",
+            encoded.display()
+        ));
+        return None;
+    }
+    Some(spec.destination)
 }
 
 fn systemd_user_paths() -> Vec<PathBuf> {
@@ -847,7 +921,7 @@ mod tests {
             ..Config::default()
         };
         // Should return without error or panic
-        assert!(apply(&config, Path::new("/tmp"), false).is_ok());
+        assert!(apply(&config, Path::new("/tmp"), &[], &[], false).is_ok());
     }
 
     #[test]
@@ -857,7 +931,7 @@ mod tests {
         // On kernels without landlock this prints a warning;
         // on kernels with landlock it enforces rules.
         // Either way it must not panic.
-        assert!(apply(&config, Path::new("/tmp"), false).is_ok());
+        assert!(apply(&config, Path::new("/tmp"), &[], &[], false).is_ok());
     }
 
     #[test]
@@ -866,7 +940,7 @@ mod tests {
             lockdown: Some(true),
             ..Config::default()
         };
-        let _ = apply(&config, Path::new("/tmp"), false);
+        let _ = apply(&config, Path::new("/tmp"), &[], &[], false);
     }
 
     #[test]
@@ -876,7 +950,7 @@ mod tests {
             no_landlock: Some(true),
             ..Config::default()
         };
-        assert!(apply(&config, Path::new("/tmp"), false).is_err());
+        assert!(apply(&config, Path::new("/tmp"), &[], &[], false).is_err());
     }
 
     #[test]
@@ -1051,6 +1125,65 @@ mod tests {
 
         let _ = std::fs::remove_file(&ro_extra);
         let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[test]
+    fn normal_paths_extra_maps_use_jail_destination() {
+        let destination = std::env::temp_dir().join(format!(
+            "ai-jail-landlock-map-destination-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&destination);
+        std::fs::create_dir_all(&destination).unwrap();
+        let source = PathBuf::from("/host/source-not-visible");
+        let config = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            rw_maps: vec![
+                crate::config::MapSpec {
+                    source: source.clone(),
+                    destination: destination.clone(),
+                }
+                .encode(),
+            ],
+            ..Config::default()
+        };
+
+        let (_, rw) = collect_normal_paths(&config, Path::new("/tmp"), false);
+
+        assert!(rw.contains(&destination));
+        assert!(!rw.contains(&source));
+
+        let _ = std::fs::remove_dir_all(&destination);
+    }
+
+    #[test]
+    fn normal_paths_exact_mounted_destination_keeps_colon_opaque() {
+        let root = std::env::temp_dir().join(format!(
+            "ai-jail-landlock-colon-destination-{}",
+            std::process::id()
+        ));
+        let destination = root.join("name:/etc");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&destination).unwrap();
+        let config = Config {
+            no_gpu: Some(true),
+            no_docker: Some(true),
+            ..Config::default()
+        };
+
+        let (_, rw) = collect_normal_paths_with_mounted_paths(
+            &config,
+            Path::new("/tmp"),
+            &[],
+            std::slice::from_ref(&destination),
+            false,
+        );
+
+        assert!(rw.contains(&destination));
+        assert!(!rw.contains(&PathBuf::from("/etc")));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,4 +1,6 @@
 use crate::config::Config;
+#[cfg(any(target_os = "macos", test))]
+use crate::config::MapSpec;
 use crate::output;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -837,15 +839,29 @@ pub fn build_launch_command(config: &Config) -> LaunchCommand {
 pub fn apply_landlock(
     config: &Config,
     project_dir: &Path,
+    mounted_ro_paths: &[PathBuf],
+    mounted_rw_paths: &[PathBuf],
     verbose: bool,
 ) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
-        landlock::apply(config, project_dir, verbose)
+        landlock::apply(
+            config,
+            project_dir,
+            mounted_ro_paths,
+            mounted_rw_paths,
+            verbose,
+        )
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (config, project_dir, verbose);
+        let _ = (
+            config,
+            project_dir,
+            mounted_ro_paths,
+            mounted_rw_paths,
+            verbose,
+        );
         Ok(())
     }
 }
@@ -900,6 +916,57 @@ pub fn platform_notes(config: &Config) {
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
+fn prepare_seatbelt_maps(
+    paths: &[PathBuf],
+    access: &str,
+) -> Result<Vec<PathBuf>, String> {
+    let mut prepared = Vec::new();
+    for encoded in paths {
+        let spec = match MapSpec::parse(encoded) {
+            Ok(spec) => spec,
+            Err(reason) => {
+                output::warn(&format!(
+                    "Invalid {access} map {}: {reason}; skipping.",
+                    encoded.display()
+                ));
+                continue;
+            }
+        };
+        if let Err(reason) = spec.validate() {
+            output::warn(&format!(
+                "Invalid {access} map {}: {reason}; skipping.",
+                encoded.display()
+            ));
+            continue;
+        }
+        if spec.is_alternate() {
+            return Err(format!(
+                "alternate map destinations are not supported on macOS: {}; \
+                 use Linux/bubblewrap or map the path at its host location",
+                encoded.display()
+            ));
+        }
+        if !path_exists(&spec.source) {
+            output::warn(&format!(
+                "Path {} not found, skipping.",
+                spec.source.display()
+            ));
+            continue;
+        }
+        prepared.push(spec.encode());
+    }
+    Ok(prepared)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn prepare_seatbelt_config(config: &Config) -> Result<Config, String> {
+    let mut prepared = config.clone();
+    prepared.rw_maps = prepare_seatbelt_maps(&config.rw_maps, "read-write")?;
+    prepared.ro_maps = prepare_seatbelt_maps(&config.ro_maps, "read-only")?;
+    Ok(prepared)
+}
+
 pub fn build(
     guard: &SandboxGuard,
     config: &Config,
@@ -913,7 +980,8 @@ pub fn build(
     #[cfg(target_os = "macos")]
     {
         let _ = guard;
-        Ok(seatbelt::build(config, project_dir, verbose))
+        let prepared = prepare_seatbelt_config(config)?;
+        Ok(seatbelt::build(&prepared, project_dir, verbose))
     }
 }
 
@@ -930,7 +998,8 @@ pub fn dry_run(
     #[cfg(target_os = "macos")]
     {
         let _ = guard;
-        Ok(seatbelt::dry_run(config, project_dir, verbose))
+        let prepared = prepare_seatbelt_config(config)?;
+        Ok(seatbelt::dry_run(&prepared, project_dir, verbose))
     }
 }
 
@@ -949,6 +1018,50 @@ mod tests {
             .unwrap_or(0);
         std::env::temp_dir()
             .join(format!("ai-jail-{prefix}-{}-{nonce}", std::process::id()))
+    }
+
+    #[test]
+    fn seatbelt_config_rejects_alternate_map_destinations() {
+        let config = Config {
+            ro_maps: vec![PathBuf::from("/host/data:/jail/data")],
+            ..Config::default()
+        };
+
+        let error = prepare_seatbelt_config(&config).unwrap_err();
+
+        assert!(error.contains("alternate map destinations"));
+        assert!(error.contains("Linux/bubblewrap"));
+    }
+
+    #[test]
+    fn seatbelt_config_keeps_existing_same_path_maps() {
+        let path = temp_test_dir("seatbelt-map-existing");
+        std::fs::create_dir_all(&path).unwrap();
+        let config = Config {
+            rw_maps: vec![path.clone()],
+            ..Config::default()
+        };
+
+        let prepared = prepare_seatbelt_config(&config).unwrap();
+
+        assert_eq!(prepared.rw_maps, vec![path.clone()]);
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn seatbelt_config_skips_invalid_and_missing_same_path_maps() {
+        let config = Config {
+            ro_maps: vec![
+                PathBuf::from("/"),
+                PathBuf::from(":/invalid"),
+                PathBuf::from("/definitely/missing/ai-jail-map"),
+            ],
+            ..Config::default()
+        };
+
+        let prepared = prepare_seatbelt_config(&config).unwrap();
+
+        assert!(prepared.ro_maps.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds support for mounting a host path at a different destination inside the sandbox:

- `ai-jail --map ~/.ssh/ai-jail:~/.ssh claude`

Existing same-path mappings remain unchanged:

- `ai-jail --map /opt/datasets claude`

The same `SOURCE:DESTINATION` syntax is supported in the `ro_maps` and `rw_maps` TOML fields.

## Behavior

- Expands `~` independently on both sides.
- Resolves relative source and destination paths against the project directory.
- Preserves the existing read-only-before-read-write mount ordering.
- Classifies in-project mappings by destination, preventing the project bind from shadowing them.
- Refuses root, malformed, missing, and non-UTF-8 paths with a warning.
- Keeps `--overlay-map` behavior unchanged.
- Rejects alternate destinations explicitly on macOS because `sandbox-exec` cannot remap paths.

The first colon is always treated as the separator. Additional colons belong to the destination, so source paths containing a literal colon are not supported.

## Security

Only mappings successfully created by bubblewrap are forwarded to Landlock. Destinations are passed through hidden internal arguments as opaque paths, preventing colon-containing destinations from being reparsed or widening the Landlock policy.

## Compatibility

The existing `rw_maps` and `ro_maps` configuration types remain unchanged, and previously generated configurations without alternate destinations continue to work as before.

## Verification

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`: 535 passed, 1 ignored
- `cargo build --release`

The macOS rejection logic is covered by platform-independent tests. A macOS Rust target was not available for local cross-compilation.