### PR TITLE
Add Kimi Code CLI support (~/.kimi-code read-write)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Pass `--private-home` or set `private_home = true` to skip this automatic dotdir
 - `.gnupg`, `.aws`, `.ssh`, `.mozilla`, `.thunderbird`, `.basilisk-dev`, `.sparrow`
 
 **Mounted read-write (AI tools and build caches):**
-- `.gemini`, `.claude`, `.crush`, `.codex`, `.aider`, `.kiro`, `.soulforge`, `.grok`, `.agents`, `.omp`, `.pi`, `.pi-lens`, `.config`, `.cargo`, `.cache`, `.docker`
+- `.gemini`, `.claude`, `.crush`, `.codex`, `.aider`, `.kiro`, `.soulforge`, `.grok`, `.agents`, `.omp`, `.pi`, `.pi-lens`, `.kimi-code`, `.config`, `.cargo`, `.cache`, `.docker`
 
 **Everything else:** mounted read-only.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ USAGE:
     ai-jail [OPTIONS] [--] [COMMAND [ARGS...]]
 
 COMMANDS (positional):
-    gemini, claude, codex, opencode, crush, soulforge, grok, pi, bash
+    gemini, claude, codex, opencode, crush, soulforge, grok, pi, kimi, bash
                                             Known AI tool presets
     status                                 Show current .ai-jail config
     Any other string                       Passed through as the command
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn help_lists_pi_preset() {
-        assert!(HELP.contains("grok, pi, bash"));
+        assert!(HELP.contains("grok, pi, kimi, bash"));
     }
 
     #[test]

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -4404,6 +4404,29 @@ mod tests {
     }
 
     #[test]
+    fn regression_kimi_code_home_dir_is_writable() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir()
+            .join(format!("ai-jail-kimi-code-home-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        let kimi_code = home.join(".kimi-code");
+        std::fs::create_dir_all(kimi_code.join("sessions")).unwrap();
+
+        let _home = EnvVarGuard::set("HOME", &home);
+        let mounts = discover_home_dotfiles(false, &[], &[], false);
+
+        assert!(
+            mounts.iter().any(|m| matches!(
+                m,
+                Mount::Bind { src, dest } if src == &kimi_code && dest == &kimi_code
+            )),
+            "~/.kimi-code must be mounted read-write so kimi can write sessions and logs"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
     fn home_gitignore_is_mounted_read_only() {
         let _lock = ENV_LOCK.lock().unwrap();
         let home = std::env::temp_dir()

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1797,8 +1797,16 @@ mod tests {
     #[test]
     fn cannot_deny_rw_required_dirs() {
         let required = [
-            ".cargo", ".cache", ".config", ".claude", ".gemini", ".kiro",
-            ".omp", ".pi", ".pi-lens", ".kimi-code",
+            ".cargo",
+            ".cache",
+            ".config",
+            ".claude",
+            ".gemini",
+            ".kiro",
+            ".omp",
+            ".pi",
+            ".pi-lens",
+            ".kimi-code",
         ];
         for name in required {
             let extra = vec![name.to_string()];

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -214,6 +214,7 @@ const DOTDIR_RW: &[&str] = &[
     ".omp",
     ".pi",
     ".pi-lens",
+    ".kimi-code",
     ".config",
     ".cargo",
     ".cache",
@@ -1723,6 +1724,7 @@ mod tests {
             ".omp",
             ".pi",
             ".pi-lens",
+            ".kimi-code",
         ] {
             assert!(DOTDIR_RW.contains(name), "{name} should be in rw list");
         }
@@ -1796,7 +1798,7 @@ mod tests {
     fn cannot_deny_rw_required_dirs() {
         let required = [
             ".cargo", ".cache", ".config", ".claude", ".gemini", ".kiro",
-            ".omp", ".pi", ".pi-lens",
+            ".omp", ".pi", ".pi-lens", ".kimi-code",
         ];
         for name in required {
             let extra = vec![name.to_string()];
@@ -1821,6 +1823,8 @@ mod tests {
         assert!(is_dotdir_rw("pi"));
         assert!(is_dotdir_rw(".pi-lens"));
         assert!(is_dotdir_rw("pi-lens"));
+        assert!(is_dotdir_rw(".kimi-code"));
+        assert!(is_dotdir_rw("kimi-code"));
         assert!(!is_dotdir_rw(".aws"));
         assert!(!is_dotdir_rw(".my_secrets"));
     }


### PR DESCRIPTION
## Problem

`ai-jail kimi` fails at startup. Kimi Code CLI keeps all of its state
(sessions, logs, credentials, oauth, updates) under `~/.kimi-code`, and
unknown home dotdirs are mounted read-only, so the agent dies immediately:

```
[logger] write failed: EROFS
error: Internal error
ENOENT: no such file or directory, mkdir '/home/<user>/.kimi-code/sessions/wd_...'
```

## Fix

Same class of fix as the `~/.omp` one in v1.2.0: add `.kimi-code` to
`DOTDIR_RW` in `src/sandbox/mod.rs` (shared by the Linux bwrap and macOS
seatbelt paths), list `kimi` as a known preset in `--help`, and document
the dotdir in the README.

## Tests

- New `regression_kimi_code_home_dir_is_writable` bwrap test proving
  `~/.kimi-code` is emitted as a read-write bind (mirrors the omp/pi
  regression tests)
- Extended the dotdir allowlist tests so `.kimi-code` cannot regress back
  to read-only or user-deniable behavior
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and full `cargo test`
  (571 tests) all green
- Verified end-to-end on Linux: `ai-jail --exec kimi -p "..."` now starts,
  writes its session state, and completes successfully