### PR TITLE
Resolve the Docker socket from $DOCKER_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ Change the wrapper command to `exec ai-jail --browser=hard chromium "$@"` if des
 
 In `--lockdown`, project is mounted read-only and host write mounts are removed. For linked Git worktrees, validated external Git metadata is still exposed read-only unless disabled with `--no-worktree`.
 
+The Docker socket is the first of `$DOCKER_HOST` (when it is a `unix://` path), `/var/run/docker.sock`, or `~/.docker/run/docker.sock` that exists. Rootless Docker and Podman put their socket under `$XDG_RUNTIME_DIR`, so export `$DOCKER_HOST` to point at it — starting the service does not set it for you.
+
 In browser profile mode, the project is mounted read-only, `$HOME` is private tmpfs, normal host dotdirs are not mounted, and soft browser state is the only persistent browser-specific write mount.
 
 In `--private-home` mode, normal host dotdirs are not exposed, but the project remains read-write and explicit `--map` / `--rw-map` mounts still work. On Linux this is a private tmpfs `$HOME`; on macOS it is enforced with seatbelt read/write allowlists because `sandbox-exec` cannot create a replacement home mount. This is useful for non-agent or experimental workloads where you want normal project access without exposing your real `~/.config`, `~/.cache`, or tool state.

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const DOCKER_SOCKET: &str = "/var/run/docker.sock";
 const WSL_DOCKER_DESKTOP_CLI_TOOLS: &str = "/mnt/wsl/docker-desktop/cli-tools";
 /// Also granted read-write by Landlock (`collect_normal_paths`) —
 /// keep the two in sync via this shared constant.
@@ -1985,15 +1984,15 @@ fn discover_gpu(verbose: bool) -> Vec<Mount> {
 }
 
 fn discover_docker() -> Vec<Mount> {
-    discover_docker_paths(
-        Path::new(DOCKER_SOCKET),
-        Path::new(WSL_DOCKER_DESKTOP_CLI_TOOLS),
-    )
+    let Some(sock) = super::docker_socket() else {
+        return Vec::new();
+    };
+    discover_docker_paths(&sock, Path::new(WSL_DOCKER_DESKTOP_CLI_TOOLS))
 }
 
 fn discover_docker_paths(sock: &Path, wsl_cli_tools: &Path) -> Vec<Mount> {
     let mut mounts = Vec::new();
-    if super::path_exists(sock) {
+    if super::docker_socket_usable(sock) {
         mounts.push(Mount::Bind {
             src: sock.to_path_buf(),
             dest: sock.to_path_buf(),

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -654,14 +654,13 @@ fn collect_normal_paths_with_mounted_paths(
     // Docker socket grants effective root on the host. Opt-in only
     // (issue #88): exposed solely via --docker / `no_docker = false`,
     // never by default.
-    if config.docker_enabled() {
-        let sock = PathBuf::from("/var/run/docker.sock");
-        if super::path_exists(&sock) {
-            if verbose {
-                output::verbose("Landlock: docker socket rw");
-            }
-            rw.push(sock);
+    if config.docker_enabled()
+        && let Some(sock) = super::docker_socket()
+    {
+        if verbose {
+            output::verbose("Landlock: docker socket rw");
         }
+        rw.push(sock);
     }
 
     // Tailscale socket: read-write — Landlock runs INSIDE the bwrap

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -666,6 +666,51 @@ fn path_exists(p: &Path) -> bool {
     p.exists() || p.symlink_metadata().is_ok()
 }
 
+/// Host path of the Docker/Podman socket to expose, if any: the
+/// first candidate we can actually reach.
+///
+/// `$DOCKER_HOST` leads because it outranks every other endpoint
+/// source in the Docker CLI's own resolution order, and rootless
+/// Docker's setup instructs exporting it. Rootless Podman keeps its
+/// socket under `$XDG_RUNTIME_DIR`, while the `podman-docker` compat
+/// package symlinks `/var/run/docker.sock` to the *rootful* socket
+/// under root-only `/run/podman` — the wrong daemon, and unreachable.
+///
+/// Docker contexts (`~/.docker/config.json`) are not consulted. That
+/// misses setups that register a context without exporting
+/// `$DOCKER_HOST` and whose socket is not one of the paths below
+/// (Colima's `~/.colima/<profile>/docker.sock`, for one); add context
+/// parsing if that turns up in practice.
+pub(crate) fn docker_socket() -> Option<PathBuf> {
+    let docker_host = std::env::var("DOCKER_HOST").ok();
+    let candidates = [
+        docker_host.as_deref().and_then(docker_host_socket_path),
+        Some(PathBuf::from("/var/run/docker.sock")),
+        Some(home_dir().join(".docker/run/docker.sock")),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|p| docker_socket_usable(p))
+}
+
+/// `$DOCKER_HOST` as a bindable socket path, if it names one.
+/// `tcp://` and `ssh://` reach the daemon over the network and
+/// `npipe://` is a Windows named pipe; none of them is a path we can
+/// bind, so they drop out of the candidate list.
+fn docker_host_socket_path(value: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(value.strip_prefix("unix://")?);
+    path.is_absolute().then_some(path)
+}
+
+/// Unlike [`path_exists`], this rejects a symlink whose target cannot
+/// be stat'd. bwrap resolves the link itself and aborts the entire
+/// launch with `Can't find source path ...: Permission denied`, so an
+/// optional socket we cannot reach must be skipped, not mounted.
+pub(crate) fn docker_socket_usable(p: &Path) -> bool {
+    p.exists()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GitWorktreePaths {
     pub git_dir: PathBuf,
@@ -1072,11 +1117,7 @@ fn docker_passthrough_active(config: &Config, socket_present: bool) -> bool {
 }
 
 fn warn_docker_passthrough(config: &Config) {
-    let candidates = [
-        PathBuf::from("/var/run/docker.sock"),
-        home_dir().join(".docker/run/docker.sock"),
-    ];
-    let socket_present = candidates.iter().any(|p| path_exists(p));
+    let socket_present = docker_socket().is_some();
     if docker_passthrough_active(config, socket_present) {
         output::warn(
             "Docker socket passthrough is enabled: the sandboxed process \
@@ -2075,6 +2116,142 @@ mod tests {
             command_home_paths_impl("./agent", &home, &path_env).is_empty()
         );
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    fn docker_socket_fixture(tag: &str) -> PathBuf {
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-docker-host-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn docker_socket_prefers_reachable_docker_host() {
+        let _lock = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let root = docker_socket_fixture("host");
+        let sock = root.join("podman.sock");
+        std::fs::File::create(&sock).unwrap();
+        let _guard = crate::test_utils::EnvVarGuard::set(
+            "DOCKER_HOST",
+            format!("unix://{}", sock.display()),
+        );
+
+        // Wins over the well-known paths whether or not they exist.
+        assert_eq!(docker_socket(), Some(sock));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn docker_socket_skips_unreachable_docker_host() {
+        // Backward compat: a stale or unreachable $DOCKER_HOST must
+        // not suppress the candidates behind it.
+        let _lock = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let root = docker_socket_fixture("stale");
+        let missing = root.join("gone.sock");
+        let _guard = crate::test_utils::EnvVarGuard::set(
+            "DOCKER_HOST",
+            format!("unix://{}", missing.display()),
+        );
+
+        let resolved = docker_socket();
+
+        assert_ne!(resolved, Some(missing));
+        // Whatever is left is one of the well-known paths, or nothing
+        // — this runs on hosts with and without a Docker socket.
+        if let Some(p) = resolved {
+            assert!(
+                p == PathBuf::from("/var/run/docker.sock")
+                    || p == home_dir().join(".docker/run/docker.sock"),
+                "unexpected fallback: {}",
+                p.display()
+            );
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn docker_host_socket_path_accepts_only_absolute_unix_paths() {
+        assert_eq!(
+            docker_host_socket_path("unix:///run/user/1000/podman/podman.sock"),
+            Some(PathBuf::from("/run/user/1000/podman/podman.sock"))
+        );
+
+        // No socket path to bind for these: tcp/ssh reach the daemon
+        // over the network, npipe is Windows-only.
+        for value in [
+            "tcp://localhost:2375",
+            "ssh://user@host",
+            "npipe:////./pipe/docker_engine",
+            "/run/user/1000/podman/podman.sock",
+            // Relative path — not something we can bind.
+            "unix://run/user/1000/podman/podman.sock",
+        ] {
+            assert_eq!(docker_host_socket_path(value), None, "for {value}");
+        }
+    }
+
+    #[test]
+    fn docker_socket_ignores_non_unix_docker_host() {
+        // A tcp:// endpoint must resolve exactly as an unset
+        // $DOCKER_HOST does: to the well-known paths only.
+        let _lock = crate::test_utils::ENV_LOCK.lock().unwrap();
+
+        let guard = crate::test_utils::EnvVarGuard::remove("DOCKER_HOST");
+        let unset = docker_socket();
+        drop(guard);
+
+        let _guard = crate::test_utils::EnvVarGuard::set(
+            "DOCKER_HOST",
+            "tcp://localhost:2375",
+        );
+        assert_eq!(docker_socket(), unset);
+    }
+
+    #[test]
+    fn docker_socket_rejects_unfollowable_symlink() {
+        // Regression: /var/run/docker.sock -> /run/podman/podman.sock
+        // with /run/podman mode 0700 root. path_exists() accepts the
+        // dangling link, and bwrap then aborts the whole launch with
+        // "Can't find source path: Permission denied".
+        let _lock = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let root = docker_socket_fixture("symlink");
+        let hidden = root.join("hidden");
+        std::fs::create_dir_all(&hidden).unwrap();
+        let target = hidden.join("podman.sock");
+        std::fs::File::create(&target).unwrap();
+        let link = root.join("docker.sock");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        std::fs::set_permissions(
+            &hidden,
+            std::os::unix::fs::PermissionsExt::from_mode(0o000),
+        )
+        .unwrap();
+
+        // Root traverses mode-000 directories; nothing to assert.
+        if std::fs::metadata(&target).is_ok() {
+            let _ = std::fs::set_permissions(
+                &hidden,
+                std::os::unix::fs::PermissionsExt::from_mode(0o700),
+            );
+            let _ = std::fs::remove_dir_all(&root);
+            return;
+        }
+
+        assert!(path_exists(&link), "lstat still succeeds on the link");
+        assert!(!docker_socket_usable(&link));
+
+        let _guard = crate::test_utils::EnvVarGuard::set(
+            "DOCKER_HOST",
+            format!("unix://{}", link.display()),
+        );
+        assert_ne!(docker_socket(), Some(link));
+
+        let _ = std::fs::set_permissions(
+            &hidden,
+            std::os::unix::fs::PermissionsExt::from_mode(0o700),
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -528,11 +528,10 @@ fn macos_atomic_write_paths(config: &Config) -> Vec<PathBuf> {
 }
 
 fn macos_docker_socket() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("/var/run/docker.sock"),
-        super::home_dir().join(".docker/run/docker.sock"),
-    ];
-    candidates.into_iter().find(|p| super::path_exists(p))
+    // Shared with Linux: honours $DOCKER_HOST before the well-known
+    // paths. Docker Desktop, Colima, and `podman machine` all place
+    // their socket under $HOME rather than /var/run/docker.sock.
+    super::docker_socket()
 }
 
 fn macos_lockdown_read_paths(


### PR DESCRIPTION
## Problem

`--docker` hardcoded `/var/run/docker.sock` in four places. On rootless Podman that path is a symlink to the **rootful** socket under root-only `/run/podman`, so it is both the wrong daemon and unreachable:

```
/var/run/docker.sock -> /run/podman/podman.sock
/run/podman  drwx------  root root
```

Worse, `path_exists()` is `p.exists() || p.symlink_metadata().is_ok()`. The `exists()` half is false (EACCES resolving the target) but `symlink_metadata()` succeeds on the link itself, so ai-jail emitted a bind for a socket it could not reach and bwrap aborted the whole launch:

```
$ ai-jail --docker
bwrap: Can't find source path /var/run/docker.sock: Permission denied
```

That violates the project's warn-and-skip rule — an optional socket should degrade, not kill the launch.

## Change

A shared `sandbox::docker_socket()` returns the first reachable entry from an ordered candidate list, with `$DOCKER_HOST` leading it:

```rust
let candidates = [
    docker_host.as_deref().and_then(docker_host_socket_path),
    Some(PathBuf::from("/var/run/docker.sock")),
    Some(home_dir().join(".docker/run/docker.sock")),
];
```

`$DOCKER_HOST` outranks every other endpoint source in the Docker CLI's own resolution order, and rootless Docker's setup instructs exporting it. Non-`unix://` values (`tcp://`, `ssh://`, `npipe://`) are not paths we can bind and drop out of the list, as does an unreachable value — so configurations that worked before are unaffected.

The reachability predicate is `exists()` rather than `path_exists()`, since choosing between candidates requires knowing which one actually resolves. That also fixes the unfollowable-symlink abort.

Used by all four call sites:

- `bwrap.rs` — the bind mount
- `landlock.rs` — the rw rule (without which the socket is mounted but every access to it is denied)
- `mod.rs` — the passthrough warning
- `seatbelt.rs` — the macOS profile, where Colima and `podman machine` also point `$DOCKER_HOST` under `$HOME`

Docker contexts (`~/.docker/config.json`) are deliberately **not** consulted. That misses setups which register a context without exporting `$DOCKER_HOST` and whose socket is not one of the paths above — Colima's `~/.colima/<profile>/docker.sock`, for one. Worth adding if it turns up in practice.

## Compatibility

No config or CLI surface change — `.ai-jail` files and flags are untouched. The `$DOCKER_HOST` entry only ever *adds* a candidate ahead of the historical ones, and drops out when unset, non-`unix://`, or unreachable.

## Testing

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --bins` (553 passed).

Five new unit tests: `$DOCKER_HOST` preference, unreachable fallback, non-`unix://` schemes, path parsing, and the unfollowable-symlink regression.

Verified end to end on rootless Podman (Fedora):

```
$ ai-jail --docker --dry-run | grep sock
  --bind /run/user/1000/podman/podman.sock /run/user/1000/podman/podman.sock

$ ai-jail --docker --display -- sh -c 'docker --remote ps'
CONTAINER ID  IMAGE                          ...  STATUS
f4546c379ce0  docker.io/crystaldba/postgres-mcp:latest  Up 58 minutes
...
```

## Notes for review

- `--remote` is needed above because Fedora's podman-docker shim runs podman in **local** mode, which needs `newuidmap` and cannot work inside the jail. The socket itself is correctly exposed; the client just has to be told to use it. Whether ai-jail should also export `CONTAINER_HOST` is a separate question — that would mean guessing that `docker` is really podman, which is outside `--docker`'s contract.
- With `--no-display`, the podman client fails on `mkdir /run/user/1000/libpod`. The podman CLI creates `$XDG_RUNTIME_DIR/libpod` at startup, and the Landlock rw rule for `$XDG_RUNTIME_DIR` (`landlock.rs:690`) is gated on `display_enabled()`, so the mkdir is denied. The socket rule added here covers only the socket path itself. Pre-existing client-side requirement, not addressed.
- `seatbelt.rs` is `cfg(macos)` and was never compiled locally — CI's `cargo clippy --target aarch64-apple-darwin` is the first real check on it. Its behaviour on Colima / `podman machine` / Docker Desktop is reasoned from their documented socket locations, not tested.
