### PR TITLE
chore(aur): bump to v1.16.2

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: AkitaOnRails <boss@akitaonrails.com>
 
 pkgname=ai-jail
-pkgver=1.4.0
+pkgver=1.16.2
 pkgrel=1
 pkgdesc="Sandbox wrapper for AI coding agents"
 arch=('x86_64' 'aarch64')
@@ -19,7 +19,7 @@ optdepends=(
 options=('!debug')
 conflicts=('ai-jail-bin')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('4eb4cffb2ad52bc920f97ee89653722aaf0c3d5cde9e251834a291bb5f19f137')
+sha256sums=('eb5a36789a3bbf187a6e3e9ece20b2d6d0079ac9d70d011952c5a5f0d95ea884')
 
 prepare() {
     cd "$pkgname-$pkgver"

--- a/packaging/aur/PKGBUILD-bin
+++ b/packaging/aur/PKGBUILD-bin
@@ -2,7 +2,7 @@
 
 pkgname=ai-jail-bin
 _pkgname=ai-jail
-pkgver=1.4.0
+pkgver=1.16.2
 pkgrel=1
 pkgdesc="Sandbox wrapper for AI coding agents (prebuilt binary)"
 arch=('x86_64')
@@ -26,9 +26,9 @@ source=(
 source_x86_64=("$_pkgname-$pkgver-x86_64.tar.gz::$url/releases/download/v$pkgver/$_pkgname-linux-x86_64.tar.gz")
 sha256sums=(
     '3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986'
-    '823121502ca8914d70fa806823d870d233ffcf99c63da3799089ca4a34b90e07'
+    '38508a1ae429fe29d7eb5175df7c35a127b55633703e27f7000b675b4b5ce156'
 )
-sha256sums_x86_64=('2a71a8090f57a65dacb54385a0b08ae871417a0864c75cddaef4a0a27893d0f0')
+sha256sums_x86_64=('3734e8703f122b3a6518413b7ee0514a348f0a3edb18eb1d33536d991abaabde')
 
 package() {
     install -Dm0755 -t "$pkgdir/usr/bin/"                     "ai-jail"


### PR DESCRIPTION
Update AUR packages `ai-jail` and `ai-jail-bin` to v1.16.2

## Changes

- `PKGBUILD`: bump `pkgver` to 1.16.2, reset `pkgrel=1`, update source tarball checksum
- `PKGBUILD-bin`: bump `pkgver` to 1.16.2, reset `pkgrel=1`, update checksums for `LICENSE`, `README.md`, and the x86_64 binary

## Validation

- [x] `makepkg --verifysource -p PKGBUILD`
- [x] `makepkg --verifysource -p PKGBUILD-bin`
- [x] `makepkg -Ccf -p PKGBUILD`
- [x] `makepkg -Ccf -p PKGBUILD-bin`

All passed locally in an Arch container.