### PR TITLE
fix for nix: support immutable store binaries and hermetic builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ readme = "README.md"
 keywords = ["sandbox", "ai", "security", "bubblewrap"]
 categories = ["command-line-utilities", "development-tools"]
 exclude = [
-    ".github/",
-    "docs/",
-    "dist/",
-    "packaging/",
-    ".claude/",
-    ".ai-jail",
-    ".codex",
-    ".lobster/",
+  ".github/",
+  "docs/",
+  "dist/",
+  "packaging/",
+  ".claude/",
+  ".ai-jail",
+  ".codex",
+  ".lobster/",
 ]
 
 [dependencies]
@@ -27,7 +27,13 @@ serde_json = "1"
 vt100 = "0.16"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["signal", "process", "poll", "term", "resource"] }
+nix = { version = "0.29", features = [
+  "signal",
+  "process",
+  "poll",
+  "term",
+  "resource",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ install -Dm755 target/release/ai-jail ~/.local/bin/ai-jail
 Linux requires `bwrap` (`bubblewrap`): `pacman -S bubblewrap`,
 `apt install bubblewrap`, or `dnf install bubblewrap`. `BWRAP_BIN` is accepted
 only when it canonically resolves to a root-owned executable that is not
-group- or world-writable. A typical protected Nix-store executable is
-accepted. macOS uses Apple's deprecated `/usr/bin/sandbox-exec` interface.
-Windows is not supported; use WSL2 and the Linux backend inside it.
+group- or world-writable, or to a non-root `/nix/store` executable with no
+write bits.
+macOS uses Apple's deprecated `/usr/bin/sandbox-exec` interface. Windows is not
+supported; use WSL2 and the Linux backend inside it.
 
 ## Quick start
 
@@ -81,20 +82,20 @@ worktree metadata, X11, host shared memory, terminal passthrough, update
 check, and macOS host IPC. Docker, SSH, Pictures, Tailscale, and the systemd
 user bus are also off by default.
 
-| Flag pair | Effect and security consequence |
-|---|---|
-| `--network` / `--no-network` | Enables/disables unrestricted network. `--network` permits full network exfiltration of any readable data. |
-| `--gpu` / `--no-gpu` | Enables/disables GPU device access. |
-| `--display` / `--no-display` | Enables/disables display access. Only the validated Wayland socket is mounted; ai-jail never mounts all of `XDG_RUNTIME_DIR`. X11 is separate (`--x11`). |
-| `--x11` / `--no-x11` | Enables/disables X11 separately. X11 access permits keylogging and screenshots. |
-| `--host-shm` / `--no-host-shm` | Enables/disables host `/dev/shm`; enabling it opens host cross-process IPC. |
-| `--terminal-passthrough` / `--no-terminal-passthrough` | Enables/disables raw terminal forwarding. Output is filtered through a VT parser by default; raw forwarding exposes terminal clipboard, query, and parser surface. |
-| `--agent-state` / `--no-agent-state` | Enables/disables mounting the invoked command's credential state (default off). Enables the agent to authenticate — and lets anything in the sandbox use those credentials. |
-| `--inherit-env` / `--no-inherit-env` | Default is a minimal environment allowlist. `--inherit-env` passes the full parent environment, secrets included. |
-| `--update-check` / `--no-update-check` | Enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active (default off; all other launches make no network requests). |
-| `--macos-host-ipc` / `--no-macos-host-ipc` | Enables/disables macOS Mach, IOKit, and host IPC exposure. |
-| `--worktree` / `--no-worktree` | Enables/disables validated linked-worktree common metadata, mounted read-only when enabled. |
-| `--private-home` / `--no-private-home` | Enables/disables the default private home. Disabling it is broad host-home access. |
+| Flag pair                                              | Effect and security consequence                                                                                                                                                           |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--network` / `--no-network`                           | Enables/disables unrestricted network. `--network` permits full network exfiltration of any readable data.                                                                                |
+| `--gpu` / `--no-gpu`                                   | Enables/disables GPU device access.                                                                                                                                                       |
+| `--display` / `--no-display`                           | Enables/disables display access. Only the validated Wayland socket is mounted; ai-jail never mounts all of `XDG_RUNTIME_DIR`. X11 is separate (`--x11`).                                  |
+| `--x11` / `--no-x11`                                   | Enables/disables X11 separately. X11 access permits keylogging and screenshots.                                                                                                           |
+| `--host-shm` / `--no-host-shm`                         | Enables/disables host `/dev/shm`; enabling it opens host cross-process IPC.                                                                                                               |
+| `--terminal-passthrough` / `--no-terminal-passthrough` | Enables/disables raw terminal forwarding. Output is filtered through a VT parser by default; raw forwarding exposes terminal clipboard, query, and parser surface.                        |
+| `--agent-state` / `--no-agent-state`                   | Enables/disables mounting the invoked command's credential state (default off). Enables the agent to authenticate — and lets anything in the sandbox use those credentials.               |
+| `--inherit-env` / `--no-inherit-env`                   | Default is a minimal environment allowlist. `--inherit-env` passes the full parent environment, secrets included.                                                                         |
+| `--update-check` / `--no-update-check`                 | Enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active (default off; all other launches make no network requests). |
+| `--macos-host-ipc` / `--no-macos-host-ipc`             | Enables/disables macOS Mach, IOKit, and host IPC exposure.                                                                                                                                |
+| `--worktree` / `--no-worktree`                         | Enables/disables validated linked-worktree common metadata, mounted read-only when enabled.                                                                                               |
+| `--private-home` / `--no-private-home`                 | Enables/disables the default private home. Disabling it is broad host-home access.                                                                                                        |
 
 `--allow-tcp-port` remains accepted for backward compatibility, but launch
 fails closed because UDP cannot be securely constrained through this option.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ install -Dm755 target/release/ai-jail ~/.local/bin/ai-jail
 Linux requires `bwrap` (`bubblewrap`): `pacman -S bubblewrap`,
 `apt install bubblewrap`, or `dnf install bubblewrap`. `BWRAP_BIN` is accepted
 only when it canonically resolves to a root-owned executable that is not
-group- or world-writable, or to a non-root `/nix/store` executable with no
-write bits.
+group- or world-writable, or to an executable with no write bits under a
+`/nix/store` that this user cannot write (a multi-user, root-owned store).
 macOS uses Apple's deprecated `/usr/bin/sandbox-exec` interface. Windows is not
 supported; use WSL2 and the Linux backend inside it.
 

--- a/docs/AUDIT_1.0.md
+++ b/docs/AUDIT_1.0.md
@@ -8,13 +8,13 @@ Findings sorted by **impact**, not file. Each item is written as a TODO. Nothing
 
 ### Long functions that have outgrown their original shape
 
-| Function | Lines | File | What to do |
-|---|---|---|---|
-| `pty::io_loop` | 277 | `src/pty.rs:178` | Split: SIGWINCH handling, master-read branch, stdin-read branch, status-bar redraw. The current function juggles 5 mutable state machines. |
-| `sandbox::bwrap::discover_mounts` | 178 | `src/sandbox/bwrap.rs:851` | Each `let foo_mount = if … { … }` block (ssh_agent, pictures, mask, browser_state, home_dotfiles + claude_dir, …) is a candidate for its own `fn discover_X`. |
-| `sandbox::seatbelt::generate_sbpl_profile` | 174 | `src/sandbox/seatbelt.rs:158` | Six logically distinct sections (process, IPC, network, reads, writes, atomic). Extract per-section emit helpers; the function then reads as policy structure. |
-| `config::display_status` | 130 | `src/config.rs` | Mostly `match` + `bool_opt` calls. Lift each block into a small printer helper to make the output schema obvious. |
-| `config::merge` | 97 | `src/config.rs` | Most of the body is repetitive CLI→config boolean transfer. See dedup item below. |
+| Function                                   | Lines | File                          | What to do                                                                                                                                                     |
+| ------------------------------------------ | ----- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pty::io_loop`                             | 277   | `src/pty.rs:178`              | Split: SIGWINCH handling, master-read branch, stdin-read branch, status-bar redraw. The current function juggles 5 mutable state machines.                     |
+| `sandbox::bwrap::discover_mounts`          | 178   | `src/sandbox/bwrap.rs:851`    | Each `let foo_mount = if … { … }` block (ssh_agent, pictures, mask, browser_state, home_dotfiles + claude_dir, …) is a candidate for its own `fn discover_X`.  |
+| `sandbox::seatbelt::generate_sbpl_profile` | 174   | `src/sandbox/seatbelt.rs:158` | Six logically distinct sections (process, IPC, network, reads, writes, atomic). Extract per-section emit helpers; the function then reads as policy structure. |
+| `config::display_status`                   | 130   | `src/config.rs`               | Mostly `match` + `bool_opt` calls. Lift each block into a small printer helper to make the output schema obvious.                                              |
+| `config::merge`                            | 97    | `src/config.rs`               | Most of the body is repetitive CLI→config boolean transfer. See dedup item below.                                                                              |
 
 ### Repetition that compounds with every new flag
 
@@ -37,15 +37,15 @@ Findings sorted by **impact**, not file. Each item is written as a TODO. Nothing
 
 ### Style / clippy-pedantic findings (cargo clippy -- -W clippy::pedantic counts)
 
-| Category | Count | Notes |
-|---|---|---|
-| Docstrings missing backticks around identifiers | 25 | Cosmetic; cherry-pick the most-visible public APIs. |
-| Module name repetition (e.g. `bwrap::BwrapMount`) | 10 | Worth doing if we ever re-export across modules. |
-| `.map(...).unwrap_or(...)` on `Result` | 5 | Replace with `.unwrap_or_else` or `?` where appropriate. |
-| `format!` appended to existing `String` | 4 | Use `write!`. |
-| Identical match arms with `\|` patterns | 4 | Merge. |
-| Variables can be inlined into `format!` strings | 4 | `format!("{x}")` instead of `format!("{}", x)`. |
-| Lossy/sign-changing casts (`as`) | 6 total | Audit individually — some are intentional (e.g. `u8 → u16` for terminal sizing). |
+| Category                                          | Count   | Notes                                                                            |
+| ------------------------------------------------- | ------- | -------------------------------------------------------------------------------- |
+| Docstrings missing backticks around identifiers   | 25      | Cosmetic; cherry-pick the most-visible public APIs.                              |
+| Module name repetition (e.g. `bwrap::BwrapMount`) | 10      | Worth doing if we ever re-export across modules.                                 |
+| `.map(...).unwrap_or(...)` on `Result`            | 5       | Replace with `.unwrap_or_else` or `?` where appropriate.                         |
+| `format!` appended to existing `String`           | 4       | Use `write!`.                                                                    |
+| Identical match arms with `\|` patterns           | 4       | Merge.                                                                           |
+| Variables can be inlined into `format!` strings   | 4       | `format!("{x}")` instead of `format!("{}", x)`.                                  |
+| Lossy/sign-changing casts (`as`)                  | 6 total | Audit individually — some are intentional (e.g. `u8 → u16` for terminal sizing). |
 
 ### Specific micro-issues worth fixing
 
@@ -58,7 +58,7 @@ Findings sorted by **impact**, not file. Each item is written as a TODO. Nothing
 - **The two existing `#[allow(dead_code)]` markers** in `src/sandbox/mod.rs:45` and `:81` are legitimate platform splits — keep.
 - **No other dead code surfaced** in clippy/grep passes.
 
-## Tier 3 — explicitly *not* worth doing right now
+## Tier 3 — explicitly _not_ worth doing right now
 
 - Rewriting `io_loop` into an async state machine. Tempting, but the project's "no tokio" CLAUDE.md rule is load-bearing. Sync loop with manual state is the right shape; just split it into smaller fns.
 - Switching `Result<_, String>` to a typed error enum. Useful for a future library extraction, irrelevant for a CLI that prints strings to a human.

--- a/docs/AUDIT_1.0_PLAN.md
+++ b/docs/AUDIT_1.0_PLAN.md
@@ -14,14 +14,14 @@ Goal: ship every Tier 1 + Tier 2 item from `AUDIT_1.0.md` without breaking any o
 
 Six small commits. None of them change observable behavior; all of them are caught by the existing test suite.
 
-| # | Commit | Touches | Net LOC |
-|---|---|---|---|
-| 1 | Add `merge_field!` macro + apply to `config::merge_with_global` | `src/config.rs` | −30 |
-| 2 | Apply `merge_field!` to `config::merge` (CLI → config side) | `src/config.rs` | −20 |
-| 3 | Add CLI `paired_bool_flag!` macro for `--foo / --no-foo` pairs | `src/cli.rs` | −20 |
-| 4 | Have `sbpl_regex_escape` delegate to `sbpl_escape` for the shared char table | `src/sandbox/seatbelt.rs` | −10 |
-| 5 | Lift `LinkedWorktreeFixture` into a shared `tests` submodule in `sandbox/mod.rs` | `src/sandbox/mod.rs`, `seatbelt.rs`, `landlock.rs`, `bwrap.rs` | −60 |
-| 6 | Run all PathBuf fields through `expand_tilde` in one pass in `config::merge` | `src/config.rs` | −5 |
+| #   | Commit                                                                           | Touches                                                        | Net LOC |
+| --- | -------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------- |
+| 1   | Add `merge_field!` macro + apply to `config::merge_with_global`                  | `src/config.rs`                                                | −30     |
+| 2   | Apply `merge_field!` to `config::merge` (CLI → config side)                      | `src/config.rs`                                                | −20     |
+| 3   | Add CLI `paired_bool_flag!` macro for `--foo / --no-foo` pairs                   | `src/cli.rs`                                                   | −20     |
+| 4   | Have `sbpl_regex_escape` delegate to `sbpl_escape` for the shared char table     | `src/sandbox/seatbelt.rs`                                      | −10     |
+| 5   | Lift `LinkedWorktreeFixture` into a shared `tests` submodule in `sandbox/mod.rs` | `src/sandbox/mod.rs`, `seatbelt.rs`, `landlock.rs`, `bwrap.rs` | −60     |
+| 6   | Run all PathBuf fields through `expand_tilde` in one pass in `config::merge`     | `src/config.rs`                                                | −5      |
 
 Expected: ~145 LOC removed, no behavior change. Each commit ends with the full suite green.
 
@@ -29,12 +29,12 @@ Expected: ~145 LOC removed, no behavior change. Each commit ends with the full s
 
 These are rearrangements of existing logic. Each split keeps the same control flow; only function boundaries move. Review visually after each split.
 
-| # | Commit | Function | Approach |
-|---|---|---|---|
-| 7 | Split `config::display_status` | 130 LOC | Each `match config.X { … }` block becomes a `print_X(config)` helper. |
-| 8 | Split `sandbox::seatbelt::generate_sbpl_profile` | 174 LOC | One helper per section (process, IPC, network, reads, writes, atomic, deny). Each helper takes `&mut String` and pushes its own block. |
-| 9 | Split `sandbox::bwrap::discover_mounts` | 178 LOC | Each `let foo_mount = if … { build_foo() } else { vec![] }` block already exists implicitly. Lift each computation into a named `fn discover_foo(config, …) -> Vec<Mount>` helper. |
-| 10 | Split `pty::io_loop` | 277 LOC | Higher risk. Approach: extract `handle_sigwinch`, `handle_master_read`, `handle_stdin_read`, `redraw_when_idle` into private helpers taking `&mut IoState` (a new struct holding the loop's mutable state). The for-loop body becomes ~25 lines calling them. Visually verify against current version. |
+| #   | Commit                                           | Function | Approach                                                                                                                                                                                                                                                                                               |
+| --- | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 7   | Split `config::display_status`                   | 130 LOC  | Each `match config.X { … }` block becomes a `print_X(config)` helper.                                                                                                                                                                                                                                  |
+| 8   | Split `sandbox::seatbelt::generate_sbpl_profile` | 174 LOC  | One helper per section (process, IPC, network, reads, writes, atomic, deny). Each helper takes `&mut String` and pushes its own block.                                                                                                                                                                 |
+| 9   | Split `sandbox::bwrap::discover_mounts`          | 178 LOC  | Each `let foo_mount = if … { build_foo() } else { vec![] }` block already exists implicitly. Lift each computation into a named `fn discover_foo(config, …) -> Vec<Mount>` helper.                                                                                                                     |
+| 10  | Split `pty::io_loop`                             | 277 LOC  | Higher risk. Approach: extract `handle_sigwinch`, `handle_master_read`, `handle_stdin_read`, `redraw_when_idle` into private helpers taking `&mut IoState` (a new struct holding the loop's mutable state). The for-loop body becomes ~25 lines calling them. Visually verify against current version. |
 
 `pty::io_loop` is the riskiest item in this plan. If the split looks like it might subtly change ordering, I'll commit the IoState struct first, run the full suite, then move helpers out one at a time.
 
@@ -42,13 +42,13 @@ These are rearrangements of existing logic. Each split keeps the same control fl
 
 Pure additions; no existing code changes.
 
-| # | Commit | What |
-|---|---|---|
-| 11 | `signals.rs` unit tests | Handler installation succeeds; `forward_signal(SIGWINCH)` flips the PTY pending flag without touching `CHILD_PID`; `forward_signal(SIGINT)` calls into the stored PID branch (mocked via a recordable hook). |
-| 12 | `rlimits::apply_nproc` test | Pin a low NPROC, then call `apply_nproc` and assert via `getrlimit` that hard == soft. Linux-only test, gated `#[cfg(target_os = "linux")]`. |
-| 13 | `hide_config` dedup test | When user already has `.ai-jail` in their `mask`, the auto-append step doesn't produce a duplicate `--ro-bind` triple. |
-| 14 | Browser-profile soft-mode mount existence test | Unit test: given `browser_profile = "soft"`, `discover_mounts` returns a `browser_state` mount pointing at `~/.local/share/ai-jail/browsers/<name>`. |
-| 15 | Lockdown + `allow_tcp_ports` + V4-unavailable failure-mode test | Use the existing apply_net_rules code path; assert the error message contains "Landlock V4" and "lockdown" when V4 is detected as unavailable. Hard to mock cleanly — may have to settle for documenting the path manually. |
+| #   | Commit                                                          | What                                                                                                                                                                                                                        |
+| --- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 11  | `signals.rs` unit tests                                         | Handler installation succeeds; `forward_signal(SIGWINCH)` flips the PTY pending flag without touching `CHILD_PID`; `forward_signal(SIGINT)` calls into the stored PID branch (mocked via a recordable hook).                |
+| 12  | `rlimits::apply_nproc` test                                     | Pin a low NPROC, then call `apply_nproc` and assert via `getrlimit` that hard == soft. Linux-only test, gated `#[cfg(target_os = "linux")]`.                                                                                |
+| 13  | `hide_config` dedup test                                        | When user already has `.ai-jail` in their `mask`, the auto-append step doesn't produce a duplicate `--ro-bind` triple.                                                                                                      |
+| 14  | Browser-profile soft-mode mount existence test                  | Unit test: given `browser_profile = "soft"`, `discover_mounts` returns a `browser_state` mount pointing at `~/.local/share/ai-jail/browsers/<name>`.                                                                        |
+| 15  | Lockdown + `allow_tcp_ports` + V4-unavailable failure-mode test | Use the existing apply_net_rules code path; assert the error message contains "Landlock V4" and "lockdown" when V4 is detected as unavailable. Hard to mock cleanly — may have to settle for documenting the path manually. |
 
 ## Phase 4 — Tier 2 cleanup
 
@@ -78,18 +78,18 @@ If everything's green: bump `Cargo.toml` to `1.0.0`, commit, tag, push, manually
 
 Conservatively, working sequentially with full test cycles between commits:
 
-| Phase | Commits | Estimate |
-|---|---|---|
-| 1 — boilerplate | 6 | 1 h |
-| 2 — function splits | 4 | 2 h (most of which is `io_loop`) |
-| 3 — test gaps | 5 | 1 h |
-| 4 — Tier 2 cleanup | 1 | 45 min |
-| 5 — release | 1 | 15 min |
-| **total** | **17 commits** | **~5 h** |
+| Phase               | Commits        | Estimate                         |
+| ------------------- | -------------- | -------------------------------- |
+| 1 — boilerplate     | 6              | 1 h                              |
+| 2 — function splits | 4              | 2 h (most of which is `io_loop`) |
+| 3 — test gaps       | 5              | 1 h                              |
+| 4 — Tier 2 cleanup  | 1              | 45 min                           |
+| 5 — release         | 1              | 15 min                           |
+| **total**           | **17 commits** | **~5 h**                         |
 
 Suggested workflow: run this end-to-end and report at the end of each phase (4 reports + a final tag-ready summary). At any phase boundary, review the master diff and stop or redo if needed.
 
-## What I'm explicitly *not* doing
+## What I'm explicitly _not_ doing
 
 - Async rewrite of `io_loop` (Tier 3)
 - Typed error enum replacing `Result<_, String>` (Tier 3)

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -76,7 +76,7 @@ Outstanding, in the order worth doing:
 
 1. **Scope the secrets (finishes item 4).** All eight secrets are still
    repository-level, so every job in every workflow can read them; the
-   environments gate *deployment*, not secret visibility. This is the
+   environments gate _deployment_, not secret visibility. This is the
    highest-value remaining step. Secret values cannot be copied by tooling —
    they are write-only — so re-enter them at environment scope and delete the
    repository copies:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,22 +7,22 @@ hostile workloads.
 
 ## Defaults and explicit capabilities
 
-| Capability | Linux default | macOS default | Explicit opt-in and risk |
-|---|---|---|---|
-| Private home | on | on | `--no-private-home` grants broad host-home visibility; prefer command-specific state or maps. |
-| Network | off | off | `--network` permits unrestricted traffic and therefore full network exfiltration of readable data. |
-| GPU | off | n/a | `--gpu` exposes host GPU devices/driver attack surface. |
-| Wayland | off | n/a | `--display` exposes only the validated Wayland socket, not all of `XDG_RUNTIME_DIR`. |
-| X11 | off | n/a | `--x11` permits X11 keylogging and screenshots. |
-| Host shared memory | off | n/a | `--host-shm` enables host cross-process IPC. |
-| Raw terminal protocol | filtered | filtered | `--terminal-passthrough` restores clipboard/query/parser surface; agent output passes through a filtering VT parser by default. |
-| Agent credential state | off | off | `--agent-state` mounts the invoked agent's credential state (for example Claude's `~/.claude`) on Linux and macOS; anything in the sandbox can then use those credentials. |
-| Environment variables | minimal allowlist | minimal allowlist | `--env NAME[=VALUE]` adds named variables; `--inherit-env` passes the entire parent environment, secrets included. |
-| Update check | off | off | `--update-check` enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active; all other launches make no network requests. |
-| macOS host IPC | n/a | off | `--macos-host-ipc` permits Mach, IOKit, and host IPC exposure. |
-| Linked-worktree metadata | off | off | `--worktree` exposes validated common metadata read-only. |
-| Docker | off | off | `--docker` is root-equivalent through the daemon. |
-| systemd user bus | off | n/a | `--systemd-user` can ask the host user manager to run services. |
+| Capability               | Linux default     | macOS default     | Explicit opt-in and risk                                                                                                                                                                     |
+| ------------------------ | ----------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Private home             | on                | on                | `--no-private-home` grants broad host-home visibility; prefer command-specific state or maps.                                                                                                |
+| Network                  | off               | off               | `--network` permits unrestricted traffic and therefore full network exfiltration of readable data.                                                                                           |
+| GPU                      | off               | n/a               | `--gpu` exposes host GPU devices/driver attack surface.                                                                                                                                      |
+| Wayland                  | off               | n/a               | `--display` exposes only the validated Wayland socket, not all of `XDG_RUNTIME_DIR`.                                                                                                         |
+| X11                      | off               | n/a               | `--x11` permits X11 keylogging and screenshots.                                                                                                                                              |
+| Host shared memory       | off               | n/a               | `--host-shm` enables host cross-process IPC.                                                                                                                                                 |
+| Raw terminal protocol    | filtered          | filtered          | `--terminal-passthrough` restores clipboard/query/parser surface; agent output passes through a filtering VT parser by default.                                                              |
+| Agent credential state   | off               | off               | `--agent-state` mounts the invoked agent's credential state (for example Claude's `~/.claude`) on Linux and macOS; anything in the sandbox can then use those credentials.                   |
+| Environment variables    | minimal allowlist | minimal allowlist | `--env NAME[=VALUE]` adds named variables; `--inherit-env` passes the entire parent environment, secrets included.                                                                           |
+| Update check             | off               | off               | `--update-check` enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active; all other launches make no network requests. |
+| macOS host IPC           | n/a               | off               | `--macos-host-ipc` permits Mach, IOKit, and host IPC exposure.                                                                                                                               |
+| Linked-worktree metadata | off               | off               | `--worktree` exposes validated common metadata read-only.                                                                                                                                    |
+| Docker                   | off               | off               | `--docker` is root-equivalent through the daemon.                                                                                                                                            |
+| systemd user bus         | off               | n/a               | `--systemd-user` can ask the host user manager to run services.                                                                                                                              |
 
 `--display` does not imply X11: X11 needs `--x11`. `--browser` reuses an
 isolated profile but still requires explicit `--network` and, on Linux,
@@ -54,9 +54,9 @@ settable per command in `~/.ai-jail`). Use
 ## Platform notes and residual risks
 
 Linux combines bubblewrap namespaces with Landlock, seccomp, and resource
-limits where available. `BWRAP_BIN` must resolve canonically to a root-owned,
-executable file that is not group- or world-writable. A normally protected Nix
-store executable satisfies this requirement.
+limits where available. `BWRAP_BIN` must resolve canonically either to a
+root-owned executable with no group- or world-write bits, or to a non-root
+executable under `/nix/store` with no write bits at all.
 
 macOS starts with no global reads, network, or host IPC, and supports the same
 opt-in `--agent-state` credential mounts as Linux; `--overlay-map` is honored

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -55,8 +55,11 @@ settable per command in `~/.ai-jail`). Use
 
 Linux combines bubblewrap namespaces with Landlock, seccomp, and resource
 limits where available. `BWRAP_BIN` must resolve canonically either to a
-root-owned executable with no group- or world-write bits, or to a non-root
-executable under `/nix/store` with no write bits at all.
+root-owned executable with no group- or world-write bits, or to an executable
+with no write bits at all under a `/nix/store` that the invoking user cannot
+write. A single-user Nix store owned by that user does not qualify: anything
+running as them could otherwise supply a fake bwrap and silently disable the
+sandbox.
 
 macOS starts with no global reads, network, or host IPC, and supports the same
 opt-in `--agent-state` credential mounts as Linux; `--overlay-map` is honored

--- a/docs/sandbox-alternatives.md
+++ b/docs/sandbox-alternatives.md
@@ -26,28 +26,28 @@ For this use case, nothing else fits as well.
 
 **Landlock** (`landlock` crate v0.4) -- Linux Security Module, kernel 5.13+. Restricts filesystem access per-path and (since kernel 6.2) network bind/connect per-port. Works unprivileged. But it can't create namespaces, can't do bind mounts, can't set a custom hostname. It restricts what syscalls can do, not the environment the process sees.
 
-| Capability | Support |
-|---|---|
+| Capability                        | Support            |
+| --------------------------------- | ------------------ |
 | Filesystem restriction (per-path) | Yes (kernel 5.13+) |
-| Network restriction (per-port) | Yes (kernel 6.2+) |
-| Unprivileged | Yes |
-| PID/UTS/IPC namespaces | No |
-| Bind mounts | No |
-| Custom hostname / /etc/hosts | No |
-| macOS | No |
+| Network restriction (per-port)    | Yes (kernel 6.2+)  |
+| Unprivileged                      | Yes                |
+| PID/UTS/IPC namespaces            | No                 |
+| Bind mounts                       | No                 |
+| Custom hostname / /etc/hosts      | No                 |
+| macOS                             | No                 |
 
 It cannot replace bwrap, but it makes a good second barrier. If bwrap's namespace setup ever has a bug, Landlock still gives kernel-level enforcement. About 50 lines of Rust to add, and it degrades cleanly on older kernels. Worth doing eventually.
 
 **Birdcage** (`birdcage` crate, Phylum) -- wraps Landlock on Linux and sandbox-exec on macOS behind one API. The cross-platform part is appealing, but it's designed for restricting the calling process, not for launching a child in an isolated environment with custom mounts. Doesn't fit our execution model.
 
-| Capability | Support |
-|---|---|
-| Filesystem restriction | Yes |
-| Network restriction | Partial |
-| Unprivileged | Yes |
-| Namespaces | No |
-| Bind mounts | No |
-| Cross-platform | Yes (Linux + macOS) |
+| Capability             | Support             |
+| ---------------------- | ------------------- |
+| Filesystem restriction | Yes                 |
+| Network restriction    | Partial             |
+| Unprivileged           | Yes                 |
+| Namespaces             | No                  |
+| Bind mounts            | No                  |
+| Cross-platform         | Yes (Linux + macOS) |
 
 **Extrasafe** (`extrasafe` crate) -- friendly Rust API over seccomp-bpf. Filters which syscalls a process can make. Complementary to namespaces, not a replacement. bwrap already drops capabilities and sets `PR_SET_NO_NEW_PRIVS`, so the marginal benefit is small for the added complexity.
 

--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772334676,
-        "narHash": "sha256-Jrc0J3AH+iNJDlUze3+FJZv2R0BZnhANFnD52V4kyvI=",
+        "lastModified": 1786849542,
+        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9879be11f30fd3bbf848e653a7f991549e8973b5",
+        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
 
           hooks = {
             deadnix.enable = true;
-            nixfmt-rfc-style.enable = true;
+            nixfmt.enable = true;
             treefmt = {
               enable = true;
               package = formatter;
@@ -87,8 +87,12 @@
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
 
-          buildInputs = [ pkgs.bubblewrap ];
-          nativeBuildInputs = [ pkgs.makeWrapper ];
+          nativeBuildInputs = [
+            pkgs.makeWrapper
+            pkgs.bubblewrap
+          ];
+
+          BWRAP_BIN = "${pkgs.bubblewrap}/bin/bwrap";
 
           postFixup = ''
             wrapProgram "$out/bin/ai-jail" \

--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -40,10 +40,10 @@ cp target/release/ai-jail ~/.local/bin/
 
 ## Supported agents
 
-| Command | Agent |
-|---------|-------|
-| `ai-jail claude` | Claude Code |
-| `ai-jail codex` | GPT Codex |
-| `ai-jail opencode` | OpenCode |
-| `ai-jail crush` | Crush |
-| `ai-jail bash` | Debug shell |
+| Command            | Agent       |
+| ------------------ | ----------- |
+| `ai-jail claude`   | Claude Code |
+| `ai-jail codex`    | GPT Codex   |
+| `ai-jail opencode` | OpenCode    |
+| `ai-jail crush`    | Crush       |
+| `ai-jail bash`     | Debug shell |

--- a/releases/v0.3.0.md
+++ b/releases/v0.3.0.md
@@ -6,19 +6,19 @@
 
 ### Permissions added to the SBPL profile
 
-| Rule | Why |
-|------|-----|
-| `process-info* (target same-sandbox)` | `os.cpus()` in Node.js/Bun, process introspection |
-| `mach-host*` | `host_processor_info()` — without it npm/yarn get 0 CPUs and serialize all work |
-| `ipc-posix-sem` | Python `multiprocessing` (SemLock) |
-| `/dev/ptmx` read+write | PTY master device for `openpty()`, needed by git credential helpers and interactive shells |
-| `/dev/ttys*` read+write | PTY slave devices |
-| `iokit-open` | Power management and hardware queries |
+| Rule                                  | Why                                                                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `process-info* (target same-sandbox)` | `os.cpus()` in Node.js/Bun, process introspection                                          |
+| `mach-host*`                          | `host_processor_info()` — without it npm/yarn get 0 CPUs and serialize all work            |
+| `ipc-posix-sem`                       | Python `multiprocessing` (SemLock)                                                         |
+| `/dev/ptmx` read+write                | PTY master device for `openpty()`, needed by git credential helpers and interactive shells |
+| `/dev/ttys*` read+write               | PTY slave devices                                                                          |
+| `iokit-open`                          | Power management and hardware queries                                                      |
 
 ### Writable paths added
 
-| Path | Why |
-|------|-----|
+| Path                                | Why                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------- |
 | `$TMPDIR` / `/private/var/folders/` | macOS per-user temp dir — used by Node.js, cargo, npm, Python, and virtually every build tool |
-| `/private/var/tmp` | Persistent temp directory |
-| `~/Library/Caches/` | macOS-native caches (Xcode tooling, Homebrew, etc.) |
+| `/private/var/tmp`                  | Persistent temp directory                                                                     |
+| `~/Library/Caches/`                 | macOS-native caches (Xcode tooling, Homebrew, etc.)                                           |

--- a/releases/v0.4.0.md
+++ b/releases/v0.4.0.md
@@ -11,38 +11,38 @@ ai-jail now applies [Landlock](https://landlock.io/) filesystem access control a
 
 ### New CLI flags
 
-| Flag | Description |
-|------|-------------|
-| `--landlock` | Explicitly enable Landlock (default) |
+| Flag            | Description                               |
+| --------------- | ----------------------------------------- |
+| `--landlock`    | Explicitly enable Landlock (default)      |
 | `--no-landlock` | Disable Landlock, fall back to bwrap-only |
 
 ### New config field
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| Field         | Type | Default        | Description                  |
+| ------------- | ---- | -------------- | ---------------------------- |
 | `no_landlock` | bool | not set (auto) | `true` disables Landlock LSM |
 
 ### Normal mode Landlock rules
 
-| Path | Access |
-|------|--------|
-| `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/etc`, `/opt`, `/sys`, `/run` | read-only |
-| `/proc`, `/tmp`, `/dev`, `/dev/shm`, project directory | read-write |
-| Home dotdirs in DOTDIR_RW list (`.claude`, `.config`, `.cargo`, `.cache`, etc.) | read-write |
-| `~/.local`, `~/.claude.json` | read-write |
-| `~/.gitconfig` | read-only |
-| Other home dotdirs (not in deny list) | read-only |
-| Extra `--rw-map` / `--map` paths | read-write / read-only |
-| Docker socket, GPU devices (if enabled) | read-write |
-| bwrap binary | read+execute |
+| Path                                                                            | Access                 |
+| ------------------------------------------------------------------------------- | ---------------------- |
+| `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/etc`, `/opt`, `/sys`, `/run`       | read-only              |
+| `/proc`, `/tmp`, `/dev`, `/dev/shm`, project directory                          | read-write             |
+| Home dotdirs in DOTDIR_RW list (`.claude`, `.config`, `.cargo`, `.cache`, etc.) | read-write             |
+| `~/.local`, `~/.claude.json`                                                    | read-write             |
+| `~/.gitconfig`                                                                  | read-only              |
+| Other home dotdirs (not in deny list)                                           | read-only              |
+| Extra `--rw-map` / `--map` paths                                                | read-write / read-only |
+| Docker socket, GPU devices (if enabled)                                         | read-write             |
+| bwrap binary                                                                    | read+execute           |
 
 ### Lockdown mode Landlock rules
 
-| Path | Access |
-|------|--------|
-| System paths + project directory | read-only |
-| `/proc`, `/tmp` | read-write |
-| No home dotdirs, no extra maps, no Docker, no GPU | — |
+| Path                                              | Access     |
+| ------------------------------------------------- | ---------- |
+| System paths + project directory                  | read-only  |
+| `/proc`, `/tmp`                                   | read-write |
+| No home dotdirs, no extra maps, no Docker, no GPU | —          |
 
 ## Fixes
 

--- a/releases/v0.5.0.md
+++ b/releases/v0.5.0.md
@@ -22,18 +22,18 @@ The preference is stored in `$HOME/.ai-jail` (user-level, not per-project) and p
 
 ### New CLI flags
 
-| Flag | Description |
-|------|-------------|
-| `-s`, `--status-bar` | Enable status bar (dark theme) |
+| Flag                 | Description                     |
+| -------------------- | ------------------------------- |
+| `-s`, `--status-bar` | Enable status bar (dark theme)  |
 | `--status-bar=light` | Enable status bar (light theme) |
-| `--no-status-bar` | Disable status bar |
+| `--no-status-bar`    | Disable status bar              |
 
 ### New config fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `no_status_bar` | bool | not set (disabled) | `false` enables the status bar |
-| `status_bar_style` | string | `"dark"` | `"dark"` or `"light"` theme |
+| Field              | Type   | Default            | Description                    |
+| ------------------ | ------ | ------------------ | ------------------------------ |
+| `no_status_bar`    | bool   | not set (disabled) | `false` enables the status bar |
+| `status_bar_style` | string | `"dark"`           | `"dark"` or `"light"` theme    |
 
 These fields live in `$HOME/.ai-jail` (global user config), not in the per-project `.ai-jail`.
 

--- a/releases/v1.16.2.md
+++ b/releases/v1.16.2.md
@@ -10,7 +10,7 @@ because intermediate directories were missing inside the sandbox.
 
 ### Fixed
 
-- Only emit an extra resolv bind when the *first symlink hop* lives under
+- Only emit an extra resolv bind when the _first symlink hop_ lives under
   `/run/` or `/tmp/` (e.g. Fedora toolbox's `/run/host/etc/resolv.conf`).
 - Symlink chains whose intermediate hops live outside tmpfs (NixOS
   `/nix/store/...`, WSL `/mnt/wsl/...`) keep the previous single-canonical

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -539,6 +539,7 @@ const LOCAL_SHARE_RW: &[&str] = &[
 ];
 
 const BWRAP_ENV_VAR: &str = "BWRAP_BIN";
+const NIX_STORE: &str = "/nix/store";
 const BWRAP_CANDIDATES: &[&str] = &[
     "/usr/bin/bwrap",
     "/bin/bwrap",
@@ -631,7 +632,8 @@ fn should_use_new_session() -> bool {
 fn trusted_bwrap_path(path: &Path) -> Option<PathBuf> {
     let canonical = path.canonicalize().ok()?;
     let metadata = canonical.metadata().ok()?;
-    let in_nix_store = canonical.starts_with("/nix/store");
+    let in_nix_store = canonical.starts_with(NIX_STORE)
+        && nix_store_is_protected(Path::new(NIX_STORE));
     trusted_binary_metadata(
         metadata.file_type().is_file(),
         metadata.uid(),
@@ -639,6 +641,26 @@ fn trusted_bwrap_path(path: &Path) -> Option<PathBuf> {
         in_nix_store,
     )
     .then_some(canonical)
+}
+
+/// Whether the Nix store itself is beyond the reach of whoever runs
+/// ai-jail.
+///
+/// `trusted_binary_metadata` trusts a *non-root-owned* executable purely
+/// because it lives in the store, so that relaxation is only sound while the
+/// store cannot be written by this user. A multi-user Nix store is root-owned
+/// (typically `root:nixbld`, mode 1775) and qualifies; a single-user store
+/// owned by the invoking user does not, because anyone able to run code as
+/// that user could then drop in a fake bwrap and silently disable the
+/// sandbox.
+fn nix_store_is_protected(store: &Path) -> bool {
+    store.metadata().is_ok_and(|m| {
+        m.is_dir() && nix_store_metadata_is_protected(m.uid(), m.mode())
+    })
+}
+
+fn nix_store_metadata_is_protected(uid: u32, mode: u32) -> bool {
+    uid == 0 || mode & 0o222 == 0
 }
 
 fn trusted_binary_metadata(
@@ -5348,6 +5370,20 @@ mod tests {
         assert!(!trusted_binary_metadata(true, 1000, 0o555, false));
         assert!(!trusted_binary_metadata(true, 0, 0o775, false));
         assert!(!trusted_binary_metadata(true, 0, 0o644, false));
+    }
+
+    #[test]
+    fn nix_store_metadata_must_be_unwritable_by_this_user() {
+        // Multi-user store: root-owned, group-writable for nixbld.
+        assert!(nix_store_metadata_is_protected(0, 0o1775));
+        assert!(nix_store_metadata_is_protected(0, 0o755));
+        // Read-only store owned by someone else is still fine.
+        assert!(nix_store_metadata_is_protected(1000, 0o555));
+        // Single-user store the invoking user can write: the
+        // non-root-owned relaxation must not apply, or anyone running
+        // as that user could drop in a fake bwrap.
+        assert!(!nix_store_metadata_is_protected(1000, 0o755));
+        assert!(!nix_store_metadata_is_protected(1000, 0o775));
     }
 
     #[test]

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -539,8 +539,13 @@ const LOCAL_SHARE_RW: &[&str] = &[
 ];
 
 const BWRAP_ENV_VAR: &str = "BWRAP_BIN";
-const BWRAP_CANDIDATES: &[&str] =
-    &["/usr/bin/bwrap", "/bin/bwrap", "/usr/local/bin/bwrap"];
+const BWRAP_CANDIDATES: &[&str] = &[
+    "/usr/bin/bwrap",
+    "/bin/bwrap",
+    "/usr/local/bin/bwrap",
+    "/run/wrappers/bin/bwrap",
+    "/run/current-system/sw/bin/bwrap",
+];
 
 /// Fixed path inside the sandbox where ai-jail is bind-mounted
 /// for the Landlock wrapper.  Lives under /tmp (always a fresh
@@ -575,6 +580,15 @@ pub(crate) fn bwrap_binary_path() -> Result<PathBuf, String> {
         let p = PathBuf::from(candidate);
         if let Some(path) = trusted_bwrap_path(&p) {
             return Ok(path);
+        }
+    }
+
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            let candidate = dir.join("bwrap");
+            if let Some(path) = trusted_bwrap_path(&candidate) {
+                return Ok(path);
+            }
         }
     }
 
@@ -617,16 +631,32 @@ fn should_use_new_session() -> bool {
 fn trusted_bwrap_path(path: &Path) -> Option<PathBuf> {
     let canonical = path.canonicalize().ok()?;
     let metadata = canonical.metadata().ok()?;
+    let in_nix_store = canonical.starts_with("/nix/store");
     trusted_binary_metadata(
         metadata.file_type().is_file(),
         metadata.uid(),
         metadata.mode(),
+        in_nix_store,
     )
     .then_some(canonical)
 }
 
-fn trusted_binary_metadata(is_file: bool, uid: u32, mode: u32) -> bool {
-    is_file && uid == 0 && mode & 0o111 != 0 && mode & 0o022 == 0
+fn trusted_binary_metadata(
+    is_file: bool,
+    uid: u32,
+    mode: u32,
+    in_nix_store: bool,
+) -> bool {
+    if !is_file || mode & 0o111 == 0 {
+        return false;
+    }
+    if uid == 0 {
+        mode & 0o022 == 0
+    } else if in_nix_store {
+        mode & 0o222 == 0
+    } else {
+        false
+    }
 }
 
 fn new_hosts_file() -> Result<(PathBuf, std::fs::File), String> {
@@ -1893,6 +1923,33 @@ fn build_deny_mounts(
     mounts
 }
 
+fn optional_ro_bind(path: &Path) -> Option<Mount> {
+    if path.is_dir() {
+        let path = path.to_path_buf();
+        Some(Mount::RoBind {
+            src: path.clone(),
+            dest: path,
+        })
+    } else {
+        None
+    }
+}
+
+fn path_resolves_under(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .canonicalize()
+            .is_ok_and(|canonical| canonical.starts_with(prefix))
+}
+
+fn needs_nix_mount(hosts_dest: &Path, nix_root: &Path) -> bool {
+    path_resolves_under(hosts_dest, nix_root)
+        || std::env::current_exe()
+            .is_ok_and(|p| path_resolves_under(&p, nix_root))
+        || std::env::var_os(BWRAP_ENV_VAR)
+            .is_some_and(|p| path_resolves_under(Path::new(&p), nix_root))
+}
+
 fn discover_base(
     hosts_mount: (&Path, &Path),
     resolv_mount: Option<(&Path, &Path)>,
@@ -1913,10 +1970,11 @@ fn discover_base_with_nix_root(
     nix_root: &Path,
 ) -> Vec<Mount> {
     let (hosts_file, hosts_dest) = hosts_mount;
-    let mut mounts = vec![Mount::RoBind {
-        src: "/usr".into(),
-        dest: "/usr".into(),
-    }];
+    let mut mounts = Vec::new();
+
+    if let Some(m) = optional_ro_bind(Path::new("/usr")) {
+        mounts.push(m);
+    }
 
     // /bin, /lib, /lib64, /sbin: on merged-/usr distros these are
     // symlinks to /usr/* and we recreate the symlink inside the
@@ -1944,34 +2002,28 @@ fn discover_base_with_nix_root(
         // else: does not exist, skip
     }
 
-    // On NixOS, /etc/hosts can be a symlink into /nix/store.
-    // The private hosts bind below is in the base group, before user
-    // --map/ro_maps are applied, so mount /nix early when the resolved
-    // destination needs it.
-    if hosts_dest.starts_with(nix_root) && nix_root.is_dir() {
-        mounts.push(Mount::RoBind {
-            src: nix_root.to_path_buf(),
-            dest: nix_root.to_path_buf(),
-        });
+    // On NixOS and Nix environments, /etc/hosts can be a symlink into /nix/store,
+    // or ai-jail/bwrap itself runs from /nix/store and requires its dynamic
+    // dependencies.
+    if needs_nix_mount(hosts_dest, nix_root) {
+        mounts.extend(optional_ro_bind(nix_root));
     }
 
+    if let Some(m) = optional_ro_bind(Path::new("/etc")) {
+        mounts.push(m);
+    }
+    mounts.push(Mount::FileRoBind {
+        src: hosts_file.to_path_buf(),
+        dest: hosts_dest.to_path_buf(),
+    });
+    // /opt is optional on some hosts; bwrap rejects missing bind sources.
+    if let Some(m) = optional_ro_bind(Path::new("/opt")) {
+        mounts.push(m);
+    }
+    if let Some(m) = optional_ro_bind(Path::new("/sys")) {
+        mounts.push(m);
+    }
     mounts.extend([
-        Mount::RoBind {
-            src: "/etc".into(),
-            dest: "/etc".into(),
-        },
-        Mount::FileRoBind {
-            src: hosts_file.to_path_buf(),
-            dest: hosts_dest.to_path_buf(),
-        },
-        Mount::RoBind {
-            src: "/opt".into(),
-            dest: "/opt".into(),
-        },
-        Mount::RoBind {
-            src: "/sys".into(),
-            dest: "/sys".into(),
-        },
         Mount::Dev {
             dest: "/dev".into(),
         },
@@ -2813,6 +2865,28 @@ mod tests {
             dest: "/tmp".into(),
         };
         assert_eq!(m.to_args(), vec!["--bind", "/tmp", "/tmp"]);
+    }
+
+    #[test]
+    fn optional_ro_bind_mounts_directories_and_skips_other_paths() {
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-optional-ro-bind-{}", std::process::id()));
+        let directory = root.join("directory");
+        let file = root.join("file");
+        let missing = root.join("missing");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(&file, b"not a directory").unwrap();
+
+        assert!(matches!(
+            optional_ro_bind(&directory),
+            Some(Mount::RoBind { src, dest })
+                if src == directory && dest == directory
+        ));
+        assert!(optional_ro_bind(&file).is_none());
+        assert!(optional_ro_bind(&missing).is_none());
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -3893,6 +3967,17 @@ mod tests {
             .any(|w| w[0] == "--ro-bind" && w[1] == p && w[2] == p)
     }
 
+    fn prepend_path(dir: &Path) -> std::ffi::OsString {
+        std::env::var_os("PATH").map_or_else(
+            || dir.as_os_str().to_os_string(),
+            |old| {
+                let mut paths = vec![dir.to_path_buf()];
+                paths.extend(std::env::split_paths(&old));
+                std::env::join_paths(paths).unwrap()
+            },
+        )
+    }
+
     #[test]
     fn private_home_binds_command_binary_from_home() {
         // Regression for #81: `ai-jail --private-home claude` must be
@@ -3901,7 +3986,7 @@ mod tests {
         let home = installer_layout_home("private");
         let _home = EnvVarGuard::set("HOME", &home);
         let _path =
-            EnvVarGuard::set("PATH", home.join(".local/bin").as_os_str());
+            EnvVarGuard::set("PATH", prepend_path(&home.join(".local/bin")));
 
         let config = Config {
             command: vec!["agent".into()],
@@ -3937,7 +4022,7 @@ mod tests {
         let home = installer_layout_home("lockdown");
         let _home = EnvVarGuard::set("HOME", &home);
         let _path =
-            EnvVarGuard::set("PATH", home.join(".local/bin").as_os_str());
+            EnvVarGuard::set("PATH", prepend_path(&home.join(".local/bin")));
 
         let config = Config {
             command: vec!["agent".into()],
@@ -5255,11 +5340,33 @@ mod tests {
     }
 
     #[test]
-    fn trusted_bwrap_metadata_requires_root_nonwritable_executable() {
-        assert!(trusted_binary_metadata(true, 0, 0o755));
-        assert!(!trusted_binary_metadata(true, 1000, 0o755));
-        assert!(!trusted_binary_metadata(true, 0, 0o775));
-        assert!(!trusted_binary_metadata(true, 0, 0o644));
+    fn trusted_bwrap_metadata_requires_root_or_nix_store_nonwritable_executable()
+     {
+        assert!(trusted_binary_metadata(true, 0, 0o755, false));
+        assert!(trusted_binary_metadata(true, 1000, 0o555, true));
+        assert!(!trusted_binary_metadata(true, 1000, 0o755, true));
+        assert!(!trusted_binary_metadata(true, 1000, 0o555, false));
+        assert!(!trusted_binary_metadata(true, 0, 0o775, false));
+        assert!(!trusted_binary_metadata(true, 0, 0o644, false));
+    }
+
+    #[test]
+    fn needs_nix_mount_triggers_for_nix_hosts_dest() {
+        let nix = Path::new("/nix");
+        let hosts_in_nix = Path::new("/nix/store/1234-hosts/hosts");
+        assert!(needs_nix_mount(hosts_in_nix, nix));
+
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-nix-mount-test-{}", std::process::id()));
+        let nix_dir = root.join("nix/store/pkg");
+        let symlink = root.join("symlink-to-nix");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&nix_dir).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&nix_dir, &symlink).unwrap();
+
+        assert!(path_resolves_under(&symlink, &root.join("nix")));
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1609,6 +1609,7 @@ mod tests {
 
     #[test]
     fn browser_soft_profile_uses_ai_jail_state_dir() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let cfg = Config {
             command: vec!["chromium".into()],
             browser_profile: Some("soft".into()),

--- a/tests/helpers/escape_helper.c
+++ b/tests/helpers/escape_helper.c
@@ -26,9 +26,16 @@
 #include <sys/personality.h>
 #include <sys/ptrace.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+
+static int is_directory(const char *path)
+{
+    struct stat st;
+    return (stat(path, &st) == 0 && S_ISDIR(st.st_mode));
+}
 
 #define BLOCKED() \
     do { puts("BLOCKED"); exit(0); } while (0)
@@ -208,21 +215,34 @@ static void test_network(void)
 }
 
 /*
- * Try to create a file in /usr (read-only system directory).
- * Blocked by bwrap ro-bind mount + Landlock ro rules.
+ * Attempt to create a file in a read-only system directory (/usr, /nix, or /etc).
+ * Blocked by bwrap ro-bind mount and Landlock ro rules.
  */
 static void test_write_sys(void)
 {
     errno = 0;
-    FILE *f = fopen("/usr/.sandbox_test", "w");
+    const char *target = NULL;
+    if (is_directory("/usr"))
+        target = "/usr/.sandbox_test";
+    else if (is_directory("/nix"))
+        target = "/nix/.sandbox_test";
+    else if (is_directory("/etc"))
+        target = "/etc/.sandbox_test";
+
+    if (target == NULL) {
+        fprintf(stderr, "SKIPPED: no system directory (/usr, /nix, /etc) available to test\n");
+        exit(2);
+    }
+
+    FILE *f = fopen(target, "w");
     if (f == NULL) {
         if (errno == EPERM || errno == EACCES || errno == EROFS)
             BLOCKED();
         ALLOWED("(fopen errno=%d)", errno);
     }
     fclose(f);
-    unlink("/usr/.sandbox_test");
-    ALLOWED("(file created in /usr!)");
+    unlink(target);
+    ALLOWED("(file created in %s!)", target);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sandbox_escape.rs
+++ b/tests/sandbox_escape.rs
@@ -194,6 +194,12 @@ fn lockdown_run(args: &[&str]) -> Output {
 fn assert_blocked(output: &Output, test_name: &str) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(2)
+        && (stdout.contains("SKIPPED") || stderr.contains("SKIPPED"))
+    {
+        eprintln!("SKIPPED: {test_name} (prerequisites not available)");
+        return;
+    }
     assert!(
         stdout.contains("BLOCKED"),
         "{test_name}: expected BLOCKED, got stdout={stdout:?} \

--- a/tests/sandbox_escape.rs
+++ b/tests/sandbox_escape.rs
@@ -194,18 +194,33 @@ fn lockdown_run(args: &[&str]) -> Output {
 fn assert_blocked(output: &Output, test_name: &str) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if output.status.code() == Some(2)
-        && (stdout.contains("SKIPPED") || stderr.contains("SKIPPED"))
-    {
-        eprintln!("SKIPPED: {test_name} (prerequisites not available)");
-        return;
-    }
     assert!(
         stdout.contains("BLOCKED"),
         "{test_name}: expected BLOCKED, got stdout={stdout:?} \
          stderr={stderr:?} exit={:?}",
         output.status.code()
     );
+}
+
+/// Like [`assert_blocked`], but tolerates the helper reporting SKIPPED
+/// (exit code 2).
+///
+/// Only the read-only-system-directory probes may legitimately skip: a host
+/// without /usr, /nix or /etc has no such directory to attempt a write into.
+/// Every other escape probe must reach a real BLOCKED verdict, so the skip
+/// path is deliberately NOT in `assert_blocked` itself — a shared skip would
+/// let any future breakage that makes the helper exit 2 turn this whole
+/// security suite into silent passes.
+fn assert_blocked_or_skipped(output: &Output, test_name: &str) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(2)
+        && (stdout.contains("SKIPPED") || stderr.contains("SKIPPED"))
+    {
+        eprintln!("SKIPPED: {test_name} (no read-only system directory)");
+        return;
+    }
+    assert_blocked(output, test_name);
 }
 
 /// Helper: run the compiled C helper inside normal sandbox.
@@ -280,7 +295,7 @@ fn sandbox_blocks_write_to_usr() {
     require_bwrap!();
     require_helper!();
     let out = helper_normal("write_sys");
-    assert_blocked(&out, "write to /usr/");
+    assert_blocked_or_skipped(&out, "write to /usr/");
 }
 
 #[test]
@@ -362,5 +377,5 @@ fn lockdown_blocks_write_to_usr() {
     require_bwrap_net!();
     require_helper!();
     let out = helper_lockdown("write_sys");
-    assert_blocked(&out, "write to /usr/ in lockdown");
+    assert_blocked_or_skipped(&out, "write to /usr/ in lockdown");
 }


### PR DESCRIPTION
Rust 1.97.1 exposed a few problems in the Nix build and sandbox setup. This change fixes downstream flake imports, makes `bwrap` discovery work on NixOS, avoids failing on missing host directories, and keeps the build tests hermetic.

### Changes
- Updated `rust-overlay` in `flake.lock` for the Rust `1.97.1` toolchain and replaced the deprecated `nixfmt-rfc-style.enable` setting with `nixfmt.enable`.
- Treat binaries in `/nix/store` as trusted only when they are immutable. Root-owned binaries remain supported, while non-root store files must have no write bits. The policy is documented in `README.md` and `docs/SECURITY.md`.
- Look for `bwrap` in the NixOS wrapper paths and in `$PATH`.
- Bind `/opt`, `/usr`, `/etc`, `/sys`, and `/nix` only when those directories exist. This avoids `bwrap` failures in minimal systems and Nix build chroots.
- Keep the `/nix` mount scoped to environments where `/etc/hosts` or the running executable or `bwrap` resolves under `/nix/store`.
- Pass `BWRAP_BIN` into the Nix derivation and add `bubblewrap` to `nativeBuildInputs`.
- Make the escape helper tolerate systems without `/usr`, `/nix`, or `/etc`, and have the corresponding test handle the resulting `SKIPPED` status.
- Protect `browser_soft_profile_uses_ai_jail_state_dir` with `ENV_LOCK` and preserve the existing `$PATH` in the `bwrap` installer tests.
- Apply `treefmt` to the changed documentation and configuration files.

### Verification
- `cargo test`: 659 tests passed, 0 failed, 2 ignored (627 unit tests + 32 integration tests).
- `cargo clippy --all-targets -- -D warnings`: Clean.
- `nix build ./ai-jail`: Succeeded.
- `nix flake check ./ai-jail`: Passed all pre-commit and treefmt checks with zero warnings.
- Downstream flake import evaluated successfully.

