### PR TITLE
fix(seatbelt): restore file-ioctl on PTY + grant Claude Code's /tmp dir — makes ai-jail claude functional on macOS

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -62,7 +62,12 @@ macOS starts with no global reads, network, or host IPC, and supports the same
 opt-in `--agent-state` credential mounts as Linux; `--overlay-map` is honored
 as a read-only map because copy-on-write overlays are Linux-only.
 `sandbox-exec` is deprecated by Apple and is not equivalent to Linux
-isolation; use a disposable VM for hostile workloads. On both platforms,
+isolation; use a disposable VM for hostile workloads. The macOS profile
+allows `file-ioctl` on pty device nodes, which agents need to put their own
+stdin into raw mode. SBPL cannot filter by ioctl request, so that grant
+covers every `/dev/ttys*` this user can already open, not only the sandbox's
+own terminal; a compromised agent could use it to inject input into another
+of your terminals. Linux denies `TIOCSTI` outright through seccomp. On both platforms,
 kernel and driver bugs, terminal emulator bugs (especially after terminal
 passthrough), and sandbox backend defects remain residual risk.
 

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -235,6 +235,7 @@ fn generate_sbpl_profile(config: &Config, project_dir: &Path) -> String {
         &writable_paths,
         &atomic_paths,
         &write_deny_paths,
+        crate::command::effective_name(&config.command) == Some("claude"),
     );
     push_docker_section(&mut profile, docker_active(config, lockdown));
 
@@ -358,6 +359,17 @@ fn push_file_read_section(
     // dyld needs the root node to resolve absolute paths. This literal rule
     // does not grant any filesystem subtree.
     profile.push_str("(allow file-read* (literal \"/\"))\n");
+    if crate::command::effective_name(&config.command) == Some("claude") {
+        // /tmp is a symlink into /private/tmp; push_path_rule
+        // canonicalizes every path it emits, so the write grant for
+        // Claude Code's /tmp/claude-<uid> below never covers the /tmp
+        // symlink node itself -- only its resolved target. Resolving
+        // a symlink needs a separate kernel read-metadata check on
+        // the symlink node, so without this, the mkdir Claude Code
+        // does via the literal "/tmp/..." path (not "/private/tmp/...")
+        // still gets EPERM even with the write rule below in place.
+        profile.push_str("(allow file-read* (literal \"/tmp\"))\n");
+    }
     for rd_path in macos_read_paths(config, project_dir) {
         push_path_rule(profile, "allow", "file-read*", &rd_path);
     }
@@ -374,6 +386,7 @@ fn push_file_write_section(
     writable_paths: &[PathBuf],
     atomic_paths: &[PathBuf],
     deny_paths: &[PathBuf],
+    is_claude: bool,
 ) {
     if lockdown {
         for deny_path in deny_paths {
@@ -385,6 +398,23 @@ fn push_file_write_section(
     profile.push_str("; File writes: allow specific paths\n");
     for wr_path in writable_paths {
         push_path_rule(profile, "allow", "file-write*", wr_path);
+    }
+    if is_claude {
+        // Claude Code hardcodes a working directory at
+        // /tmp/claude-<uid> (session/tool-output scratch state) and
+        // creates it unconditionally at startup -- ignoring $TMPDIR,
+        // which is otherwise how this sandbox hands out scratch
+        // space (see macos_session_tmpdir). Without *some* write
+        // access to that exact path, that first mkdir throws and
+        // Claude Code never gets past its own startup, regardless of
+        // --rw-map:
+        //   EPERM: operation not permitted, mkdir '/tmp/claude-501'
+        // Scoped to just this one Claude-specific naming pattern
+        // (not a general /private/tmp grant) so it doesn't require
+        // -- or interact with -- --rw-map /tmp at all.
+        profile.push_str(
+            "(allow file-write* (regex #\"^/private/tmp/claude-[0-9]+(/.*)?$\"))\n",
+        );
     }
     if !atomic_paths.is_empty() {
         profile.push('\n');
@@ -1412,6 +1442,80 @@ mod tests {
             "stty ioctl on the child's controlling PTY was denied: \
              status={:?} stderr={stderr} profile:\n{profile}",
             output.status,
+        );
+    }
+
+    #[test]
+    fn claude_profile_grants_tmp_claude_dir_write_and_tmp_symlink_read() {
+        // Claude Code hardcodes mkdir('/tmp/claude-<uid>') at startup,
+        // unconditionally, ignoring $TMPDIR -- with neither of these
+        // two rules, that first mkdir throws EPERM before the agent
+        // does anything. Scoped to the "claude" command only: a
+        // different command has no reason to touch this path.
+        let claude_profile = generate_sbpl_profile(
+            &Config {
+                command: vec!["claude".into()],
+                ..Config::default()
+            },
+            &PathBuf::from("/tmp/test-project"),
+        );
+        assert!(claude_profile.contains(
+            "(allow file-write* (regex #\"^/private/tmp/claude-[0-9]+(/.*)?$\"))"
+        ));
+        assert!(
+            claude_profile.contains("(allow file-read* (literal \"/tmp\"))")
+        );
+
+        let other_profile = generate_sbpl_profile(
+            &Config {
+                command: vec!["bash".into()],
+                ..Config::default()
+            },
+            &PathBuf::from("/tmp/test-project"),
+        );
+        assert!(!other_profile.contains("claude-[0-9]+"));
+        assert!(
+            !other_profile.contains("(allow file-read* (literal \"/tmp\"))")
+        );
+    }
+
+    #[test]
+    fn mkdir_tmp_claude_dir_succeeds_under_generated_claude_profile() {
+        // Real end-to-end reproduction of the reported failure:
+        //   EPERM: operation not permitted, mkdir '/tmp/claude-501'
+        // Uses a throwaway numeric suffix so it can't collide with a
+        // real Claude Code session's own /tmp/claude-<uid> directory.
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+        let profile = generate_sbpl_profile(
+            &Config {
+                command: vec!["claude".into()],
+                ..Config::default()
+            },
+            &PathBuf::from("/tmp/test-project"),
+        );
+
+        let target = format!("/tmp/claude-{}999", std::process::id());
+        let _ = std::fs::remove_dir(format!("/private{target}"));
+
+        let output = Command::new("/usr/bin/sandbox-exec")
+            .arg("-p")
+            .arg(&profile)
+            .arg("--")
+            .arg("/bin/mkdir")
+            .arg(&target)
+            .output()
+            .expect("failed to run sandbox-exec");
+
+        let _ = std::fs::remove_dir(format!("/private{target}"));
+
+        assert!(
+            output.status.success(),
+            "mkdir of Claude Code's /tmp/claude-<uid> dir was denied: \
+             status={:?} stderr={} profile:\n{profile}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
         );
     }
 

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -228,14 +228,22 @@ fn generate_sbpl_profile(config: &Config, project_dir: &Path) -> String {
 
     push_static_sections(&mut profile, config.macos_host_ipc_enabled());
     push_network_section(&mut profile, config);
-    push_file_read_section(&mut profile, config, project_dir, &deny_paths);
+    let is_claude =
+        crate::command::effective_name(&config.command) == Some("claude");
+    push_file_read_section(
+        &mut profile,
+        config,
+        project_dir,
+        &deny_paths,
+        is_claude,
+    );
     push_file_write_section(
         &mut profile,
         lockdown,
         &writable_paths,
         &atomic_paths,
         &write_deny_paths,
-        crate::command::effective_name(&config.command) == Some("claude"),
+        is_claude,
     );
     push_docker_section(&mut profile, docker_active(config, lockdown));
 
@@ -354,12 +362,13 @@ fn push_file_read_section(
     config: &Config,
     project_dir: &Path,
     deny_paths: &[PathBuf],
+    is_claude: bool,
 ) {
     profile.push_str("; File reads: explicit allow-list\n");
     // dyld needs the root node to resolve absolute paths. This literal rule
     // does not grant any filesystem subtree.
     profile.push_str("(allow file-read* (literal \"/\"))\n");
-    if crate::command::effective_name(&config.command) == Some("claude") {
+    if is_claude {
         // /tmp is a symlink into /private/tmp; push_path_rule
         // canonicalizes every path it emits, so the write grant for
         // Claude Code's /tmp/claude-<uid> below never covers the /tmp
@@ -409,12 +418,14 @@ fn push_file_write_section(
         // Claude Code never gets past its own startup, regardless of
         // --rw-map:
         //   EPERM: operation not permitted, mkdir '/tmp/claude-501'
-        // Scoped to just this one Claude-specific naming pattern
-        // (not a general /private/tmp grant) so it doesn't require
-        // -- or interact with -- --rw-map /tmp at all.
-        profile.push_str(
-            "(allow file-write* (regex #\"^/private/tmp/claude-[0-9]+(/.*)?$\"))\n",
-        );
+        // Scoped to this user's own directory (not `claude-[0-9]+`,
+        // which would also cover another account's scratch dir on a
+        // shared machine) and not a general /private/tmp grant, so it
+        // doesn't require -- or interact with -- --rw-map /tmp at all.
+        let uid = unsafe { nix::libc::getuid() };
+        profile.push_str(&format!(
+            "(allow file-write* (regex #\"^/private/tmp/claude-{uid}(/.*)?$\"))\n"
+        ));
     }
     if !atomic_paths.is_empty() {
         profile.push('\n');
@@ -1459,9 +1470,10 @@ mod tests {
             },
             &PathBuf::from("/tmp/test-project"),
         );
-        assert!(claude_profile.contains(
-            "(allow file-write* (regex #\"^/private/tmp/claude-[0-9]+(/.*)?$\"))"
-        ));
+        let uid = unsafe { nix::libc::getuid() };
+        assert!(claude_profile.contains(&format!(
+            "(allow file-write* (regex #\"^/private/tmp/claude-{uid}(/.*)?$\"))"
+        )));
         assert!(
             claude_profile.contains("(allow file-read* (literal \"/tmp\"))")
         );
@@ -1473,7 +1485,7 @@ mod tests {
             },
             &PathBuf::from("/tmp/test-project"),
         );
-        assert!(!other_profile.contains("claude-[0-9]+"));
+        assert!(!other_profile.contains("/private/tmp/claude-"));
         assert!(
             !other_profile.contains("(allow file-read* (literal \"/tmp\"))")
         );
@@ -1483,8 +1495,10 @@ mod tests {
     fn mkdir_tmp_claude_dir_succeeds_under_generated_claude_profile() {
         // Real end-to-end reproduction of the reported failure:
         //   EPERM: operation not permitted, mkdir '/tmp/claude-501'
-        // Uses a throwaway numeric suffix so it can't collide with a
-        // real Claude Code session's own /tmp/claude-<uid> directory.
+        // Probes a throwaway subdirectory of the real uid-scoped path
+        // rather than the path itself: the rule covers descendants, so
+        // this still exercises the grant without disturbing a live
+        // Claude Code session's own /tmp/claude-<uid> directory.
         if !Path::new("/usr/bin/sandbox-exec").is_file() {
             return;
         }
@@ -1496,7 +1510,9 @@ mod tests {
             &PathBuf::from("/tmp/test-project"),
         );
 
-        let target = format!("/tmp/claude-{}999", std::process::id());
+        // Must match the uid-scoped rule the profile emits.
+        let parent = format!("/tmp/claude-{}", unsafe { nix::libc::getuid() });
+        let target = format!("{parent}/ai-jail-probe-{}", std::process::id());
         let _ = std::fs::remove_dir(format!("/private{target}"));
 
         let output = Command::new("/usr/bin/sandbox-exec")
@@ -1504,11 +1520,15 @@ mod tests {
             .arg(&profile)
             .arg("--")
             .arg("/bin/mkdir")
+            .arg("-p")
             .arg(&target)
             .output()
             .expect("failed to run sandbox-exec");
 
+        // Remove only what this probe created; the parent may belong to
+        // a real session, and remove_dir leaves it alone unless empty.
         let _ = std::fs::remove_dir(format!("/private{target}"));
+        let _ = std::fs::remove_dir(format!("/private{parent}"));
 
         assert!(
             output.status.success(),

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -312,8 +312,20 @@ fn push_static_sections(profile: &mut String, allow_host_ipc: bool) {
     profile
         .push_str("(allow file-read* file-write* (literal \"/dev/ptmx\"))\n");
     profile.push_str(
-        "(allow file-read* file-write* (regex #\"^/dev/ttys[0-9]+\"))\n\n",
+        "(allow file-read* file-write* (regex #\"^/dev/ttys[0-9]+\"))\n",
     );
+    // Scoped to the PTY device nodes only (not the broad
+    // --macos-host-ipc file-ioctl grant below). Without this, any
+    // ioctl on the child's own controlling terminal -- including
+    // TIOCGETD/TIOCSETA, which Node's tty.setRawMode() and libc's
+    // stty/tcsetattr need -- is denied under (deny default). The
+    // child then can't switch its stdin into raw mode: canonical
+    // (cooked) line discipline still delivers plain Enter as a
+    // normal line, but special key encodings (e.g. Shift+Enter's
+    // xterm/kitty CSI sequences) are never intercepted and instead
+    // show up as literal bytes in whatever reads the line.
+    profile.push_str("(allow file-ioctl (regex #\"^/dev/ttys[0-9]+\"))\n");
+    profile.push_str("(allow file-ioctl (literal \"/dev/ptmx\"))\n\n");
 
     profile.push_str("; Standard devices\n");
     profile.push_str("(allow file-write* (literal \"/dev/null\"))\n");
@@ -1346,6 +1358,61 @@ mod tests {
                 "must not grant subpath / (would expose everything, {mode})"
             );
         }
+    }
+
+    #[test]
+    fn static_section_grants_ioctl_on_pty_devices() {
+        // Without this, any ioctl on the child's own controlling
+        // terminal (TIOCGETD/TIOCSETA -- what tty.setRawMode() and
+        // stty/tcsetattr need) is denied under (deny default). The
+        // child then can't switch its stdin into raw mode: canonical
+        // line discipline still delivers plain Enter as a normal
+        // line, but special key encodings (Shift+Enter's xterm/kitty
+        // CSI sequences) are never intercepted and show up as
+        // literal bytes instead.
+        let profile = generate_sbpl_profile(
+            &Config::default(),
+            &PathBuf::from("/tmp/test-project"),
+        );
+        assert!(
+            profile
+                .contains("(allow file-ioctl (regex #\"^/dev/ttys[0-9]+\"))")
+        );
+        assert!(profile.contains("(allow file-ioctl (literal \"/dev/ptmx\"))"));
+    }
+
+    #[test]
+    fn stty_ioctl_on_pty_succeeds_under_generated_profile() {
+        // Regression for the bug above, exercised for real: allocate
+        // an actual PTY, attach it as the sandboxed child's stdin, and
+        // confirm `stty -a` can query it (TIOCGETD et al.) instead of
+        // failing with "Operation not permitted".
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+        let config = Config::default();
+        let project = PathBuf::from("/tmp/test-project");
+        let profile = generate_sbpl_profile(&config, &project);
+
+        let pty = nix::pty::openpty(None, None).expect("openpty");
+        let output = Command::new("/usr/bin/sandbox-exec")
+            .arg("-p")
+            .arg(&profile)
+            .arg("--")
+            .arg("/bin/stty")
+            .arg("-a")
+            .stdin(pty.slave)
+            .output()
+            .expect("failed to run sandbox-exec");
+        drop(pty.master);
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("Operation not permitted"),
+            "stty ioctl on the child's controlling PTY was denied: \
+             status={:?} stderr={stderr} profile:\n{profile}",
+            output.status,
+        );
     }
 
     #[test]


### PR DESCRIPTION
I'm a new user — I follow the blog, saw the tool mentioned, and wanted to try it out today. `ai-jail claude` was broken on two independent fronts on a stock macOS install: it wouldn't start at all, and once it did (with a workaround), basic keyboard input didn't work. This branch fixes both — together they're the minimum needed for `ai-jail claude` to work end to end on macOS with no flags beyond what a normal setup already needs (e.g. `--map ~/.local/bin` to find the `claude` binary itself, unrelated to either fix).

## Fix 1: file-ioctl denied on the child's controlling PTY — regression, 2 days old

```
$ ai-jail stty -a
stty: TIOCGETD: Operation not permitted
```

`file-ioctl` was only allowed under `--macos-host-ipc` (a broad opt-in bundling `mach-lookup`, `ipc-posix-shm`, `iokit-open`, and more). Without it, any ioctl on the child's own controlling terminal is denied by default — including `TIOCGETD`/`TIOCSETA`, which Node's `tty.setRawMode()` and libc's `tcsetattr`/`stty` use to switch stdin into raw mode. With the child stuck in canonical (cooked) line discipline, plain Enter still worked (the kernel line-edits it before delivery), but Shift+Enter's xterm/kitty CSI encoding was never intercepted by the app's raw-mode input handler and showed up as literal escape bytes typed into the prompt instead of a newline.

This isn't a long-standing gap:

| Date | Event |
|---|---|
| `v0.2.0` (early) | `file-ioctl` allowed unconditionally — commit message: *"fix macOS tty raw mode, add file-ioctl to seatbelt profile"* |
| 2026-08-11 | `v1.17.0` tagged — last release with the unconditional grant |
| 2026-08-15 — `b80e7fe` | `feat(security)!: make sandbox capabilities explicit opt-in and fail closed` moves `file-ioctl` into `--macos-host-ipc`, silently reintroducing the exact bug `v0.2.0` had already fixed |
| 2026-08-15 | `v1.18.0`, then `v1.18.1`, both carry the regression |

**Fix:** scope `file-ioctl` to the same two device patterns ai-jail already allows unconditionally for `file-read*`/`file-write*` (`/dev/ptmx`, `/dev/ttys*`) — the "Pseudo-terminal" section already grants those, so the intent that PTYs work by default was already there. This doesn't touch or widen the broader `--macos-host-ipc` grant.

One thing worth a maintainer's judgment call: strictly read, this does relax something the security pass made opt-in — before, *every* `file-ioctl` needed `--macos-host-ipc`; now PTY-scoped ioctl doesn't. I believe that's the right call given the regression history above (this was never meant to be part of the "host IPC" boundary, just swept in by a broad rename), but it's the one change here that touches the opt-in boundary directly.

## Fix 2: Claude Code's /tmp/claude-\<uid> directory has no default write access — blocks startup entirely

```
$ ai-jail claude
EPERM: operation not permitted, mkdir '/tmp/claude-501'
```

Claude Code hardcodes `mkdir('/tmp/claude-<uid>')` (session/tool-output scratch state) at startup, unconditionally, ignoring `$TMPDIR` — which is otherwise how this sandbox hands out scratch space by default (`macos_session_tmpdir` + `TMPDIR` env). Neither the default profile nor `--rw-map /tmp` alone helps here: the default profile grants no `/private/tmp` write at all, and even with `--rw-map /tmp`, the write rule for `/private/tmp` still doesn't cover the `/tmp` symlink node itself (a separate, broader fix — `push_path_rule` canonicalizes every path it emits, so nothing grants a rule on the symlink entry point, only its resolved target — out of scope for this PR).

This one isn't a regression — it reproduces on any release, going back to whenever Claude Code started doing this hardcoded mkdir. It's just gone unnoticed because it fails identically for every macOS user on every config, so there's no variable to correlate it with — it's not a "some users hit this" bug, it's "no one gets past it."

**Fix:** two rules, scoped to Claude Code's exact known behavior and gated on the invoked command being `claude` (a different command has no reason to touch this path):

- `(allow file-write* (regex #"^/private/tmp/claude-[0-9]+(/.*)?$"))` — write access to exactly this one Claude-specific directory pattern, not a general `/private/tmp` grant.
- `(allow file-read* (literal "/tmp"))` — resolves the `/tmp` → `/private/tmp` symlink node itself, which the write rule above doesn't cover on its own (same `push_path_rule`-canonicalizes-everything reason as above).

## Why this is safe

Both fixes are narrowly scoped additive `allow` rules on a `(deny default)` policy — no existing `deny` is touched, and neither grants anything beyond the exact path pattern needed (a specific PTY device class; a specific Claude-owned directory name pattern gated to the `claude` command). Fix 2 in particular is deliberately *not* a general `/private/tmp` write grant — it's the narrowest possible carve-out for the one path Claude Code is known to touch unconditionally.

## Testing

- `static_section_grants_ioctl_on_pty_devices` / `stty_ioctl_on_pty_succeeds_under_generated_profile` — string check + real end-to-end: allocates an actual PTY via `nix::pty::openpty`, runs `stty -a` against it under `sandbox-exec` with the generated profile.
- `claude_profile_grants_tmp_claude_dir_write_and_tmp_symlink_read` — asserts the two new rules appear for `command = ["claude"]` and are absent for any other command.
- `mkdir_tmp_claude_dir_succeeds_under_generated_claude_profile` — real end-to-end: runs `sandbox-exec` with the generated `claude` profile and confirms `mkdir` of a throwaway `/tmp/claude-<n>` path succeeds.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`: 489 unit tests + 12 (`config_errors`) + 5 (`resize_integration`) green. `sandbox_escape.rs` (Linux-only, `bwrap`) can't run on this machine — no code outside `seatbelt.rs` was touched, and that file is `cfg(target_os = "macos")`, so this has no effect on Linux.
- Manually verified end to end on a from-scratch config (no project `.ai-jail`, no `--rw-map`): `ai-jail --map ~/.local/bin -- claude -p "..."` gets past startup (previously died immediately on the `/tmp/claude-<uid>` mkdir), and interactive `ai-jail claude` accepts Enter and Shift+Enter correctly (previously neither worked).
