### PR TITLE
fix for nix: userns overflowuid store check and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,20 @@ worktree metadata, X11, host shared memory, terminal passthrough, update
 check, and macOS host IPC. Docker, SSH, Pictures, Tailscale, and the systemd
 user bus are also off by default.
 
-| Flag pair | Effect and security consequence |
-|---|---|
-| `--network` / `--no-network` | Enables/disables unrestricted network. `--network` permits full network exfiltration of any readable data. |
-| `--gpu` / `--no-gpu` | Enables/disables GPU device access. |
-| `--display` / `--no-display` | Enables/disables display access. Only the validated Wayland socket is mounted; ai-jail never mounts all of `XDG_RUNTIME_DIR`. X11 is separate (`--x11`). |
-| `--x11` / `--no-x11` | Enables/disables X11 separately. X11 access permits keylogging and screenshots. |
-| `--host-shm` / `--no-host-shm` | Enables/disables host `/dev/shm`; enabling it opens host cross-process IPC. |
-| `--terminal-passthrough` / `--no-terminal-passthrough` | Enables/disables raw terminal forwarding. Output is filtered through a VT parser by default; raw forwarding exposes terminal clipboard, query, and parser surface. |
-| `--agent-state` / `--no-agent-state` | Enables/disables mounting the invoked command's credential state (default off). Enables the agent to authenticate — and lets anything in the sandbox use those credentials. |
-| `--inherit-env` / `--no-inherit-env` | Default is a minimal environment allowlist. `--inherit-env` passes the full parent environment, secrets included. |
-| `--update-check` / `--no-update-check` | Enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active (default off; all other launches make no network requests). |
-| `--macos-host-ipc` / `--no-macos-host-ipc` | Enables/disables macOS Mach, IOKit, and host IPC exposure. |
-| `--worktree` / `--no-worktree` | Enables/disables validated linked-worktree metadata. When enabled, the per-worktree git dir and the shared common dir are writable so the agent can commit; `--lockdown` keeps both read-only. |
-| `--private-home` / `--no-private-home` | Enables/disables the default private home. Disabling it is broad host-home access. |
+| Flag pair                                              | Effect and security consequence                                                                                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--network` / `--no-network`                           | Enables/disables unrestricted network. `--network` permits full network exfiltration of any readable data.                                                                                     |
+| `--gpu` / `--no-gpu`                                   | Enables/disables GPU device access.                                                                                                                                                            |
+| `--display` / `--no-display`                           | Enables/disables display access. Only the validated Wayland socket is mounted; ai-jail never mounts all of `XDG_RUNTIME_DIR`. X11 is separate (`--x11`).                                       |
+| `--x11` / `--no-x11`                                   | Enables/disables X11 separately. X11 access permits keylogging and screenshots.                                                                                                                |
+| `--host-shm` / `--no-host-shm`                         | Enables/disables host `/dev/shm`; enabling it opens host cross-process IPC.                                                                                                                    |
+| `--terminal-passthrough` / `--no-terminal-passthrough` | Enables/disables raw terminal forwarding. Output is filtered through a VT parser by default; raw forwarding exposes terminal clipboard, query, and parser surface.                             |
+| `--agent-state` / `--no-agent-state`                   | Enables/disables mounting the invoked command's credential state (default off). Enables the agent to authenticate — and lets anything in the sandbox use those credentials.                    |
+| `--inherit-env` / `--no-inherit-env`                   | Default is a minimal environment allowlist. `--inherit-env` passes the full parent environment, secrets included.                                                                              |
+| `--update-check` / `--no-update-check`                 | Enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active (default off; all other launches make no network requests).      |
+| `--macos-host-ipc` / `--no-macos-host-ipc`             | Enables/disables macOS Mach, IOKit, and host IPC exposure.                                                                                                                                     |
+| `--worktree` / `--no-worktree`                         | Enables/disables validated linked-worktree metadata. When enabled, the per-worktree git dir and the shared common dir are writable so the agent can commit; `--lockdown` keeps both read-only. |
+| `--private-home` / `--no-private-home`                 | Enables/disables the default private home. Disabling it is broad host-home access.                                                                                                             |
 
 `--allow-tcp-port` remains accepted for backward compatibility, but launch
 fails closed because UDP cannot be securely constrained through this option.

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -54,7 +54,7 @@ Configured:
 - **Item 6.** A pinned release key lives in `.github/release-keyring/`
   (`ai-jail-release.asc` plus its 40-hex fingerprint in `fingerprints.txt`),
   and `tag.gpgsign` is enabled for this repository, so CI cryptographically
-  verifies each `v*` tag against that key. v1.18.1 is the first *signed*
+  verifies each `v*` tag against that key. v1.18.1 is the first _signed_
   tag, but CI did not verify it: the keyring detection used
   `ls <file>.asc *.gpg`, whose unmatched glob made `ls` exit non-zero and
   silently selected the "not verified" branch. Fixed with a `find` test

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,22 +7,22 @@ hostile workloads.
 
 ## Defaults and explicit capabilities
 
-| Capability | Linux default | macOS default | Explicit opt-in and risk |
-|---|---|---|---|
-| Private home | on | on | `--no-private-home` grants broad host-home visibility; prefer command-specific state or maps. |
-| Network | off | off | `--network` permits unrestricted traffic and therefore full network exfiltration of readable data. |
-| GPU | off | n/a | `--gpu` exposes host GPU devices/driver attack surface. |
-| Wayland | off | n/a | `--display` exposes only the validated Wayland socket, not all of `XDG_RUNTIME_DIR`. |
-| X11 | off | n/a | `--x11` permits X11 keylogging and screenshots. |
-| Host shared memory | off | n/a | `--host-shm` enables host cross-process IPC. |
-| Raw terminal protocol | filtered | filtered | `--terminal-passthrough` restores clipboard/query/parser surface; agent output passes through a filtering VT parser by default. |
-| Agent credential state | off | off | `--agent-state` mounts the invoked agent's credential state (for example Claude's `~/.claude`) on Linux and macOS; anything in the sandbox can then use those credentials. |
-| Environment variables | minimal allowlist | minimal allowlist | `--env NAME[=VALUE]` adds named variables; `--inherit-env` passes the entire parent environment, secrets included. |
-| Update check | off | off | `--update-check` enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active; all other launches make no network requests. |
-| macOS host IPC | n/a | off | `--macos-host-ipc` permits Mach, IOKit, and host IPC exposure. |
-| Linked-worktree metadata | off | off | `--worktree` exposes validated worktree metadata read-write so git can write objects and refs; the common dir may sit outside the project. `--lockdown` keeps it read-only. |
-| Docker | off | off | `--docker` is root-equivalent through the daemon. |
-| systemd user bus | off | n/a | `--systemd-user` can ask the host user manager to run services. |
+| Capability               | Linux default     | macOS default     | Explicit opt-in and risk                                                                                                                                                                     |
+| ------------------------ | ----------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Private home             | on                | on                | `--no-private-home` grants broad host-home visibility; prefer command-specific state or maps.                                                                                                |
+| Network                  | off               | off               | `--network` permits unrestricted traffic and therefore full network exfiltration of readable data.                                                                                           |
+| GPU                      | off               | n/a               | `--gpu` exposes host GPU devices/driver attack surface.                                                                                                                                      |
+| Wayland                  | off               | n/a               | `--display` exposes only the validated Wayland socket, not all of `XDG_RUNTIME_DIR`.                                                                                                         |
+| X11                      | off               | n/a               | `--x11` permits X11 keylogging and screenshots.                                                                                                                                              |
+| Host shared memory       | off               | n/a               | `--host-shm` enables host cross-process IPC.                                                                                                                                                 |
+| Raw terminal protocol    | filtered          | filtered          | `--terminal-passthrough` restores clipboard/query/parser surface; agent output passes through a filtering VT parser by default.                                                              |
+| Agent credential state   | off               | off               | `--agent-state` mounts the invoked agent's credential state (for example Claude's `~/.claude`) on Linux and macOS; anything in the sandbox can then use those credentials.                   |
+| Environment variables    | minimal allowlist | minimal allowlist | `--env NAME[=VALUE]` adds named variables; `--inherit-env` passes the entire parent environment, secrets included.                                                                           |
+| Update check             | off               | off               | `--update-check` enables the status bar's outbound GitHub version check, run in a background thread while the interactive status bar is active; all other launches make no network requests. |
+| macOS host IPC           | n/a               | off               | `--macos-host-ipc` permits Mach, IOKit, and host IPC exposure.                                                                                                                               |
+| Linked-worktree metadata | off               | off               | `--worktree` exposes validated worktree metadata read-write so git can write objects and refs; the common dir may sit outside the project. `--lockdown` keeps it read-only.                  |
+| Docker                   | off               | off               | `--docker` is root-equivalent through the daemon.                                                                                                                                            |
+| systemd user bus         | off               | n/a               | `--systemd-user` can ask the host user manager to run services.                                                                                                                              |
 
 `--display` does not imply X11: X11 needs `--x11`. `--browser` reuses an
 isolated profile but still requires explicit `--network` and, on Linux,

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -654,9 +654,42 @@ fn trusted_bwrap_path(path: &Path) -> Option<PathBuf> {
 /// that user could then drop in a fake bwrap and silently disable the
 /// sandbox.
 fn nix_store_is_protected(store: &Path) -> bool {
-    store.metadata().is_ok_and(|m| {
+    let protected_by_metadata = store.metadata().is_ok_and(|m| {
         m.is_dir() && nix_store_metadata_is_protected(m.uid(), m.mode())
-    })
+    });
+    protected_by_metadata && !path_is_writable_by_us(store)
+}
+
+/// Whether this process can actually write into `dir`, according to the
+/// kernel rather than to a uid/mode guess.
+///
+/// Owner and mode bits only approximate the question that matters here —
+/// "could whoever runs ai-jail drop a fake bwrap in this store?" — and the
+/// approximation has blind spots: an owner that is merely *unmapped* reads
+/// back as the overflow uid whether or not we can write it, and neither
+/// supplementary groups nor ACLs are visible in `st_mode` at all. Asking the
+/// kernel answers it directly, and also treats a read-only store mount as
+/// the protection it is.
+fn path_is_writable_by_us(dir: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    // As root, W_OK succeeds almost everywhere and so tells us nothing; the
+    // ownership check is the guard in that case.
+    if unsafe { nix::libc::geteuid() } == 0 {
+        return false;
+    }
+    let Ok(c_dir) = std::ffi::CString::new(dir.as_os_str().as_bytes()) else {
+        // A path we cannot even represent is not one to trust.
+        return true;
+    };
+    unsafe {
+        nix::libc::faccessat(
+            nix::libc::AT_FDCWD,
+            c_dir.as_ptr(),
+            nix::libc::W_OK,
+            nix::libc::AT_EACCESS,
+        ) == 0
+    }
 }
 
 fn nix_store_metadata_is_protected(uid: u32, mode: u32) -> bool {
@@ -5419,6 +5452,47 @@ mod tests {
         assert!(!trusted_binary_metadata(true, 1000, 0o555, false));
         assert!(!trusted_binary_metadata(true, 0, 0o775, false));
         assert!(!trusted_binary_metadata(true, 0, 0o644, false));
+    }
+
+    #[test]
+    fn writability_probe_matches_the_kernel_not_the_mode_bits() {
+        // The uid/mode heuristic cannot see supplementary groups, ACLs, or
+        // an unmapped (overflow-uid) owner we nonetheless have write access
+        // to, so nix_store_is_protected also asks the kernel directly. The
+        // fully adversarial layout (a store owned by the overflow uid whose
+        // group we are in) needs CAP_CHOWN to build, so this exercises the
+        // probe itself against real directories.
+        if unsafe { nix::libc::geteuid() } == 0 {
+            // As root every path reads as writable; the probe is disabled
+            // and the ownership check is the guard.
+            return;
+        }
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-writable-probe-{}", std::process::id()));
+        let writable = root.join("writable");
+        let readonly = root.join("readonly");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&writable).unwrap();
+        std::fs::create_dir_all(&readonly).unwrap();
+        std::fs::set_permissions(
+            &readonly,
+            std::fs::Permissions::from_mode(0o500),
+        )
+        .unwrap();
+
+        assert!(path_is_writable_by_us(&writable));
+        assert!(!path_is_writable_by_us(&readonly));
+        // A store we can write is never protected, whatever its mode bits
+        // suggest.
+        assert!(!nix_store_is_protected(&writable));
+        // Nonexistent paths are not stores at all.
+        assert!(!nix_store_is_protected(&root.join("missing")));
+
+        let _ = std::fs::set_permissions(
+            &readonly,
+            std::fs::Permissions::from_mode(0o700),
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -660,7 +660,11 @@ fn nix_store_is_protected(store: &Path) -> bool {
 }
 
 fn nix_store_metadata_is_protected(uid: u32, mode: u32) -> bool {
-    uid == 0 || mode & 0o222 == 0
+    if uid == 0 || uid == 65534 {
+        mode & 0o002 == 0
+    } else {
+        mode & 0o222 == 0
+    }
 }
 
 fn trusted_binary_metadata(
@@ -5403,7 +5407,12 @@ mod tests {
     fn nix_store_metadata_must_be_unwritable_by_this_user() {
         // Multi-user store: root-owned, group-writable for nixbld.
         assert!(nix_store_metadata_is_protected(0, 0o1775));
+        assert!(nix_store_metadata_is_protected(65534, 0o1775));
         assert!(nix_store_metadata_is_protected(0, 0o755));
+        // World-writable stores are rejected even under root / overflowuid.
+        assert!(!nix_store_metadata_is_protected(0, 0o1777));
+        assert!(!nix_store_metadata_is_protected(65534, 0o1777));
+        assert!(!nix_store_metadata_is_protected(65534, 0o777));
         // Read-only store owned by someone else is still fine.
         assert!(nix_store_metadata_is_protected(1000, 0o555));
         // Single-user store the invoking user can write: the


### PR DESCRIPTION
Linux user namespaces can report an unmapped store owner as the kernel overflow UID, typically `65534`. A standard multi-user Nix store uses `root:nixbld` permissions with group write access, so the existing protection check rejected it inside some Nix build sandboxes and rootless environments. This change accepts the standard multi-user store layout for the overflow UID, keeps stricter checks for mapped non-root owners, and formats the documentation required by the Nix checks.

### Changes

- Allow `nix_store_metadata_is_protected` to recognize UID `65534` with standard multi-user store permissions, while still rejecting world-writable stores.
- Keep the existing requirement that mapped non-root owners have no owner, group, or other write bits.
- Add boundary tests covering overflow UID `65534` and world-writable modes `01777` and `0777`.
- Format `README.md`, `docs/SECURITY.md`, and `docs/RELEASE_SECURITY.md` with `nix fmt` to satisfy the `nix flake check` pre-commit hook.

### Verification

- `cargo test --locked`: 661 passed, 0 failed, 2 ignored.
- `cargo clippy --locked --all-targets -- -D warnings`: Clean, with 0 warnings.
- `git diff --check` and `nix fmt`: Clean, with 0 anomalies.
- `nix build ./ai-jail --no-link`: Succeeded, exit 0.
- `nix flake check ./ai-jail`: All checks passed with 0 warnings.