### PR TITLE
fix(nix): enforce sticky bit in Nix store protection check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ This is the single most important invariant of the project. Users generate `.ai-
 - Project `.ai-jail` is untrusted monotonic policy. It may tighten the effective
   sandbox but cannot enable capabilities, outside maps, ports, `claude_dir`, or
   exceptions. Capability opt-ins belong in global config or on the CLI.
-  The single exception is `trust_project_config` in the *global* config, which
+  The single exception is `trust_project_config` in the _global_ config, which
   names directories whose project files are merged with trusted semantics. The
   trust always originates in the trusted layer: a project file that sets
   `trust_project_config` itself is ignored and warned about.

--- a/releases/v1.19.1.md
+++ b/releases/v1.19.1.md
@@ -17,6 +17,7 @@
   able to replace one — the sticky bit separates them, and the binary itself
   must still carry no write bits — so the check is back to ownership and mode
   only. Thanks to @wtf9880 (#114).
+
 - **`ai-jail --init` no longer copies your global config into the repository.**
   It persisted the fully merged configuration, so a populated `~/.ai-jail`
   landed in the project's `.ai-jail`: personal absolute paths, `claude_dir`,
@@ -38,7 +39,7 @@
 ## Documentation
 
 - `env_pass` is documented. It already worked from the global config and its
-  `[commands.<name>]` tables — it is only skipped when *writing*, because
+  `[commands.<name>]` tables — it is only skipped when _writing_, because
   `NAME=VALUE` entries can carry secrets — but nothing said so, and it read as
   CLI-only. Entries in a project `.ai-jail` are ignored, since a repository
   must not pull variables out of your shell. Thanks to @zinga666 (#111).

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -646,28 +646,28 @@ fn trusted_bwrap_path(path: &Path) -> Option<PathBuf> {
 /// Whether the Nix store itself is beyond the reach of whoever runs
 /// ai-jail.
 ///
-/// `trusted_binary_metadata` trusts a *non-root-owned* executable purely
-/// because it lives in the store, so that relaxation is only sound while the
-/// store cannot be written by this user. A multi-user Nix store is root-owned
-/// (typically `root:nixbld`, mode 1775) and qualifies; a single-user store
-/// owned by the invoking user does not, because anyone able to run code as
-/// that user could then drop in a fake bwrap and silently disable the
-/// sandbox.
+/// Deliberately ownership and mode only, with no "can I write here?" probe:
+/// inside a Nix build sandbox the build user is in group `nixbld` and the
+/// standard multi-user store (`root:nixbld` mode 1775) is legitimately
+/// group-writable by that user, so a kernel writability probe rejected every
+/// NixOS install (issue #114). The sticky bit is what makes group write
+/// safe — a member may create new store paths but cannot replace someone
+/// else's — so `nix_store_metadata_is_protected` explicitly requires it on
+/// group-writable stores. A store owned by a non-root user (e.g. a single-user
+/// install) must carry no write bits at all.
 fn nix_store_is_protected(store: &Path) -> bool {
-    // Deliberately ownership and mode only, with no "can I write here?"
-    // probe. A standard multi-user store is root:nixbld mode 1775, and Nix
-    // builds run as a nixbld member, so the kernel answers "writable" for
-    // the people this is meant to protect. The sticky bit is the reason
-    // that is safe: a group member may create new store paths but cannot
-    // replace someone else's, and the binary itself is separately required
-    // to carry no write bits. Probing the directory rejected every NixOS
-    // install (issue #114).
     store.metadata().is_ok_and(|m| {
         m.is_dir() && nix_store_metadata_is_protected(m.uid(), m.mode())
     })
 }
 
 fn nix_store_metadata_is_protected(uid: u32, mode: u32) -> bool {
+    // A group-writable store requires the sticky bit so a group member
+    // cannot replace someone else's files (0775 is refused, 1775 is trusted).
+    if (mode & 0o020 != 0) && (mode & 0o1000 == 0) {
+        return false;
+    }
+
     if uid == 0 || uid == 65534 {
         mode & 0o002 == 0
     } else {
@@ -5493,6 +5493,11 @@ mod tests {
         // ownership/mode matrix below is the enforceable part.
         assert!(nix_store_metadata_is_protected(0, 0o1775));
         assert!(nix_store_metadata_is_protected(65534, 0o1775));
+
+        // Group-writable without the sticky bit is refused (e.g. 0775).
+        assert!(!nix_store_metadata_is_protected(0, 0o0775));
+        assert!(!nix_store_metadata_is_protected(65534, 0o0775));
+
         // World-writable is still refused, sticky bit or not.
         assert!(!nix_store_metadata_is_protected(0, 0o1777));
         assert!(!nix_store_metadata_is_protected(65534, 0o1777));


### PR DESCRIPTION
I noticed this while looking into Issue #114. When I first tested my previous PR, I had temporarily set `doCheck = false;` in my system-wide NixOS configuration for `ai-jail` to speed up debugging, and forgot to remove it. `cargo test` was therefore skipped, so I pinned my fork, tested the runtime manually, and sent it off without realizing that the tests were failing for everyone else.

By the time I investigated, the `faccessat` probe had already been reverted in commit `1824c25`. I was already looking into the store protection behavior, so I followed that thread a little further. The result is this PR.

### Changes

This PR builds on top of the `1824c25` revert (which removed the `faccessat` kernel probe to fix Issue #114). It adds the sticky bit check that the reverted code was relying on.

The store metadata check currently only rejects world-writable directories:

```rust
if uid == 0 || uid == 65534 {
    mode & 0o002 == 0
}
```
This accepts a group-writable `0775` store even though it has no sticky bit. A user with group access can then delete and replace files such as `bwrap`.

The check now requires the sticky bit whenever the directory is group-writable:

```rust
// If the directory is group-writable, the sticky bit MUST be present
if (mode & 0o020 != 0) && (mode & 0o1000 == 0) {
    return false;
}
```

- Keep the standard root-owned `01775` multi-user Nix store working.
- Continue rejecting world-writable stores and writable stores owned by mapped non-root users.
- Add regression coverage for rejecting `0775` while accepting the standard `01775` layout.
- Format `CLAUDE.md` and `releases/v1.19.1.md` with `nix fmt` so the repository passes the `treefmt` pre-commit check in `nix flake check`.

### Why not restore `faccessat`?

The probe checked whether the current process could write to the store. That is not the same as checking whether a user can replace an existing store binary. It also rejected the standard group-writable Nix store during builds, which is why it broke Issue #114. The sticky bit addresses the directory replacement case without rejecting `01775` stores.

There are still some limitations outside the scope of this PR:

- The metadata check does not account for file-level ACLs on `bwrap`.
- UID `65534` may represent either an unmapped owner or a real `nobody` user.
- A group member can still create a new executable in a group-writable store and select it with `BWRAP_BIN`.

### Verification
- `cargo test --bin ai-jail`: 640 passed, 0 failed.
- Added regression tests in `multi_user_nix_store_layout_is_trusted` asserting that `0o0775` is correctly rejected.
- `nix build ./ai-jail --no-link` and `nix flake check` succeeded in the standard `01775` environment.
