### PR TITLE
fix(nix): remove unnecessary runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,20 @@
 
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
+        # Only rustc + cargo + rust-std are needed to actually *build* the
+        # package. `rust` above also drags in rustfmt/clippy/rust-analyzer/
+        # rust-src/rust-docs/llvm-tools (whatever rust-toolchain.toml asks
+        # for), and since they're all part of the same aggregated
+        # derivation, their /nix/store paths get embedded as plain strings
+        # in the compiled binary (panic locations, debug info, etc.) and
+        # end up as spurious runtime dependencies of the final package.
+        rustBuild = pkgs.rust-bin.fromRustupToolchain {
+          channel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+        };
+
         rustPlatform = pkgs.makeRustPlatform {
-          rustc = rust;
-          cargo = rust;
+          rustc = rustBuild;
+          cargo = rustBuild;
         };
 
         formatter =
@@ -93,6 +104,12 @@
           ];
 
           BWRAP_BIN = "${pkgs.bubblewrap}/bin/bwrap";
+
+          # Belt-and-suspenders: strip any /nix/store path that might still
+          # get baked into the binary (panic!()/file!() locations, debug
+          # info, ...) so Nix's reference scanner has nothing left to
+          # falsely latch onto, even for the now-much-smaller build toolchain.
+          RUSTFLAGS = "--remap-path-prefix=${builtins.storeDir}=/build";
 
           postFixup = ''
             wrapProgram "$out/bin/ai-jail" \


### PR DESCRIPTION
I was wondering why ai-jail depends on rust toolchain for runtime, I asked AI about it and it fixed it([here](https://github.com/user-attachments/files/31325122/OpenRouter.Chat.Fri.Aug.21.2026.md) is the chat for reference and details)

# Before

```bash
$ nix-store --query --requisites /nix/store/xmdmmmfk61hciikn8b8xgfq2n4nivp7a-ai-jail | cat
/nix/store/h5yzhyi8j6iq4r26giryd0rh9ynsayan-libunistring-1.4.2
/nix/store/kpcd405yxfc3pfv8x4mv5j3fj54v946p-libidn2-2.3.8
/nix/store/v4zcvckzr9hqpg1f6bmkbf2q7fmszzvk-xgcc-15.3.0-libgcc
/nix/store/0d8g8n0a11v6f5m2h416ajyxmnkwc3md-glibc-2.42-67
/nix/store/161aghkjm32hxmab5blxlsl336fqqb5k-libgpg-error-1.61
/nix/store/cjgm8gv32xdrjgzbgc0zk2fypiys9ylf-gcc-15.3.0-libgcc
/nix/store/3c652d3xfl2d48xcmy43g6ahwsa0ml0v-rust-std-1.97.1-x86_64-unknown-linux-gnu
/nix/store/3r334980q5lx8x00xlfx3498hklirv3v-expand-response-params
/nix/store/dsn500c5j62qz9f49mi3nhx74jbkf6xq-pcre2-10.47
/nix/store/4dgym2zhac9vy0vrih4gsplh0wpfl13m-gnugrep-3.12
/nix/store/9a4rlpdc6cc72slb7f2prdhcvidj5rhz-gmp-6.3.0
/nix/store/4gacmljs66gjn5w2iya833ll4wbnz7hh-mpfr-4.2.2
/nix/store/5nli00pq00b48nrx6364gq1w2p3fhgcg-isl-0.20
/nix/store/c2fgns4y4c4xjvc6pq024abmxyy4dl28-glibc-2.42-67-bin
/nix/store/clhc4r76h2a65s7dnkzxai2qdwiyylpd-linux-headers-7.1
/nix/store/m300ngckdmal8wnl3bjbpwca3a5bn74c-glibc-2.42-67-dev
/nix/store/r48746qznwqxxl9qzd8f08ny8mg1dg2y-gcc-15.3.0-lib
/nix/store/skwiwbwldgdjiky0g4cijs6gb3gz5rwr-libmpc-1.4.1
/nix/store/zks9mfsn4rqr6z9g6pcj2xqzcsplj0nb-zlib-1.3.2
/nix/store/7sh9061yj9yl20ndc00rqw4d0bd80m1j-gcc-15.3.0
/nix/store/hdafzn814kg90afqsm7dq130y0aq3iaz-gmp-with-cxx-6.3.0
/nix/store/l0c9s0y8mspasl4dg91d9kqhsigqnl75-attr-2.6.0
/nix/store/njhz1f5xr4hgniy9bbb9g5k2llgsmycv-acl-2.4.0
/nix/store/97d5ygrvqj55f4nx1x34wfdcc7qn11c0-coreutils-9.11
/nix/store/byi2zpy2bgcf3dr6y0l8m50rmjj8z7q1-bash-5.3p15
/nix/store/ycl2ii3m8l35icmk212dfs6drnnijgza-binutils-2.46-lib
/nix/store/8lkj89binl0xhraqxb8bwmv0q4p3pnlr-binutils-2.46
/nix/store/j5rd8xm5zqgzcb0l19942ms7r96q0hip-binutils-wrapper-2.46
/nix/store/3d1c302vw7kc8a5vknhmn34c0pd7zm6m-gcc-wrapper-15.3.0
/nix/store/d0ijgsmbzs86l60bf9dfjlmmm2b4wh9r-llvm-tools-preview-1.97.1-x86_64-unknown-linux-gnu
/nix/store/g9wm5i7g1icq3jzcv5hdpqsw0xd0jbhg-libcap-2.78-lib
/nix/store/kpjkxs3hlgl7yxqp8cg7fkvs42zi4vfh-util-linux-minimal-2.42.2-lib
/nix/store/wflv43s0i42ysmjvw1hiw4vdiidfzwnn-libffi-3.7.1
/nix/store/z493j9b2d1v9fcnabanv10fx7kd8jlzj-libselinux-3.10
/nix/store/msrf7lbwkxmzw9igyxjbhz9qc8097yvc-glib-2.88.3
/nix/store/rvda2jwcddy9h14w9hvflngn3zijp68z-libgcrypt-1.12.2-lib
/nix/store/ixhagc730sg9fjpx8f9mpnvw4n9zzcb6-libsecret-0.21.7
/nix/store/n7phcgv6rm08zm9niccq5i67kjs6lh5q-rustc-1.97.1-x86_64-unknown-linux-gnu
/nix/store/kl2ag34pz9wqzsxp9kzwqa5gia9fc2xk-rustfmt-preview-1.97.1-x86_64-unknown-linux-gnu
/nix/store/lqndphylsxqwbwm804n473pb4sqb98sh-bubblewrap-0.11.2
/nix/store/sk02inz0a2cls9hsj9afmg3k7nw2ixg4-rust-analyzer-preview-1.97.1-x86_64-unknown-linux-gnu
/nix/store/vpd3k51q88j6j7gk04lq4gaxnvn61lk4-rust-src-1.97.1-x86_64-unknown-linux-gnu
/nix/store/vz08q7kqala27p4n0sdbmldswnkwkz2z-cargo-1.97.1-x86_64-unknown-linux-gnu
/nix/store/wrwfv1ajknnwsy7da0ncx99ncj63vk4f-rust-docs-1.97.1-x86_64-unknown-linux-gnu
/nix/store/wy6krrj0ipf7kypsvysrmbhmn791x8ss-clippy-preview-1.97.1-x86_64-unknown-linux-gnu
/nix/store/xgsynx8255qivnlx69qx2djb9kxg3lv7-rust-default-1.97.1
/nix/store/xmdmmmfk61hciikn8b8xgfq2n4nivp7a-ai-jail
```

# After
```bash
$ nix-store --query --requisites /nix/store/grlx4nx0fhc2nqcj9bj0wcgwjaf725si-ai-jail | cat
/nix/store/h5yzhyi8j6iq4r26giryd0rh9ynsayan-libunistring-1.4.2
/nix/store/kpcd405yxfc3pfv8x4mv5j3fj54v946p-libidn2-2.3.8
/nix/store/v4zcvckzr9hqpg1f6bmkbf2q7fmszzvk-xgcc-15.3.0-libgcc
/nix/store/0d8g8n0a11v6f5m2h416ajyxmnkwc3md-glibc-2.42-67
/nix/store/byi2zpy2bgcf3dr6y0l8m50rmjj8z7q1-bash-5.3p15
/nix/store/cjgm8gv32xdrjgzbgc0zk2fypiys9ylf-gcc-15.3.0-libgcc
/nix/store/dsn500c5j62qz9f49mi3nhx74jbkf6xq-pcre2-10.47
/nix/store/g9wm5i7g1icq3jzcv5hdpqsw0xd0jbhg-libcap-2.78-lib
/nix/store/z493j9b2d1v9fcnabanv10fx7kd8jlzj-libselinux-3.10
/nix/store/lqndphylsxqwbwm804n473pb4sqb98sh-bubblewrap-0.11.2
/nix/store/r48746qznwqxxl9qzd8f08ny8mg1dg2y-gcc-15.3.0-lib
/nix/store/grlx4nx0fhc2nqcj9bj0wcgwjaf725si-ai-jail
```

i still wondering why it depends on libgcc but it seems to be default rust toolchain approach