### PR TITLE
fix(seatbelt): grant the Homebrew prefix and command binaries outside $HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,30 @@ jobs:
       - name: Check macOS target
         run: cargo clippy --locked --target aarch64-apple-darwin --all-targets -- -D warnings
 
+  macos:
+    # `src/sandbox/seatbelt.rs` is `#[cfg(target_os = "macos")]`, so the Linux
+    # job only ever compiles its tests (through the cross-target clippy step).
+    # Executing them used to happen on tag push, until a09179b (v1.18.0) split
+    # the release matrix and left the macOS leg building without testing. Every
+    # seatbelt test written after that was merged unrun, and 26 of them failed
+    # the first time this job ran.
+    runs-on: macos-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.97.1
+      - run: cargo test --locked
+
   nix:
-    # The Nix build path had no CI coverage, so two NixOS regressions reached
-    # users: v1.19.0 refused its own bwrap (#114), and flake changes could
-    # only ever be validated by the reporter. `nix flake check` builds the
-    # package and runs its checkPhase, which is the same suite CI runs above.
+    # The Nix build path had no CI coverage, so NixOS regressions reached
+    # users (#114) and flake changes could only be validated by whoever sent
+    # them.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -69,5 +88,12 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+      # `flake check` realizes `checks.*` only. It reports the package as
+      # "derivation evaluated to ...ai-jail.drv" and stops there, so on its
+      # own this job proves the formatting hooks pass and nothing else.
       - name: nix flake check
         run: nix flake check --print-build-logs
+      # The build is what actually exercises the flake: buildRustPackage
+      # compiles the crate and runs the test suite in its checkPhase.
+      - name: nix build
+        run: nix build .#default --print-build-logs

--- a/src/config.rs
+++ b/src/config.rs
@@ -791,9 +791,19 @@ fn deepest_existing_ancestor(path: &Path) -> Option<(PathBuf, PathBuf)> {
 /// cannot be stat'd — fail closed). Symlinks above the project root
 /// are irrelevant: the canonicalized `stop` already resolved them.
 fn ancestor_chain_has_symlink(start: &Path, stop: &Path) -> bool {
+    // `stop` is canonical while `start` is not, so textual equality alone
+    // never fires when any component above the project root is a symlink —
+    // the walk then runs past the root and rejects on that symlink, which
+    // is exactly what this function documents as irrelevant. macOS makes it
+    // routine (`/var` -> `private/var`, `/tmp` -> `private/tmp`), but a
+    // Linux home behind a symlink hits it too.
+    let reached_stop = |path: &Path| {
+        path == stop
+            || std::fs::canonicalize(path).is_ok_and(|real| real == stop)
+    };
     let mut current = start;
     loop {
-        if current == stop {
+        if reached_stop(current) {
             return false;
         }
         match std::fs::symlink_metadata(current) {
@@ -2194,6 +2204,33 @@ env_pass = ["ANTHROPIC_API_KEY"]
 
         assert!(resolves_inside_project(
             &project.join("src/newdir/nested"),
+            &project
+        ));
+        assert!(resolves_inside_project(&project.join("newdir"), &project));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolves_inside_project_ignores_symlink_above_the_project_root() {
+        // The project root is reached through a symlink, so the
+        // canonicalized root and the caller's path spell it differently.
+        // The chain walk must still terminate at the root: a symlink
+        // *above* it was already resolved by canonicalizing, and treating
+        // it as an escape rejected every in-project map. This is the
+        // permanent state of affairs on macOS, where $TMPDIR lives under
+        // `/var` -> `private/var`.
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-resolve-above-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let real = root.join("real");
+        std::fs::create_dir_all(real.join("project/src")).unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let project = link.join("project");
+        assert!(resolves_inside_project(
+            &project.join("src/newdir"),
             &project
         ));
         assert!(resolves_inside_project(&project.join("newdir"), &project));

--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -2221,7 +2221,7 @@ fn discover_command_binary(
     verbose: bool,
 ) -> Vec<Mount> {
     let mut paths = if private_home {
-        super::command_home_paths(config)
+        super::command_paths_under(config, &super::home_dir())
     } else {
         Vec::new()
     };

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -502,28 +502,20 @@ fn home_dir() -> PathBuf {
     PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()))
 }
 
-/// Paths under `$HOME` that must stay visible in private-home mode for
-/// the sandboxed command itself to start (issue #81). Private home
-/// replaces `$HOME` with a tmpfs and skips all dotdir binds, which
-/// also hides the agent binary when it was installed under the home
-/// directory — e.g. the official Claude installer symlinks
-/// `~/.local/bin/claude` to `~/.local/share/claude/versions/<v>`.
+/// Paths below `root` that must stay visible for the sandboxed command
+/// itself to start (issue #81).
 ///
-/// Resolves the command the way exec will (host `PATH` search), then
-/// walks the symlink chain: every hop under `$HOME` is collected, and
-/// for the final regular-file target its parent directory is collected
-/// so version payloads and launcher siblings resolve. Tools with needs
-/// beyond their install directory stay on the `--map` escape hatch.
-pub(crate) fn command_home_paths(config: &Config) -> Vec<PathBuf> {
-    command_paths_under(config, &home_dir())
-}
-
-/// Paths needed to execute the configured command that live below `root`.
+/// Resolves the command the way exec will (host `PATH` search), then walks
+/// the symlink chain: every hop below `root` is collected, and for the final
+/// regular-file target its parent directory is collected so version payloads
+/// and launcher siblings resolve. Tools with needs beyond their install
+/// directory stay on the `--map` escape hatch.
 ///
-/// Linux uses this for volatile host paths such as NixOS's
-/// `/run/current-system/sw/bin`, which are hidden by the sandbox's private
-/// `/run`. Keeping the root explicit also lets the private-home handling use
-/// the same symlink-safe command resolution without broadening either mount.
+/// `root` is what each backend hides. Linux passes `$HOME`, whose tmpfs
+/// takes the agent binary with it — the official Claude installer symlinks
+/// `~/.local/bin/claude` to `~/.local/share/claude/versions/<v>` — and
+/// `/run`, which is always private and holds the NixOS system profile
+/// (#117). macOS denies by default everywhere, so it passes `/` (#120).
 pub(crate) fn command_paths_under(
     config: &Config,
     root: &Path,
@@ -2030,7 +2022,7 @@ mod tests {
     }
 
     #[test]
-    fn command_home_paths_follows_installer_symlink_chain() {
+    fn command_paths_under_follows_installer_symlink_chain() {
         // Regression for #81: PATH entry + final target's parent dir
         // must both surface so private-home mode can exec the agent.
         let home = command_home_fixture("chain");
@@ -2090,7 +2082,7 @@ mod tests {
     }
 
     #[test]
-    fn command_home_paths_include_managed_outer_and_inner_executables() {
+    fn command_paths_under_include_managed_outer_and_inner_executables() {
         let _lock = ENV_LOCK.lock().unwrap();
         let home = std::env::temp_dir()
             .join(format!("ai-jail-managed-cmd-home-{}", std::process::id()));
@@ -2127,12 +2119,15 @@ mod tests {
             ..Config::default()
         };
 
-        assert_eq!(command_home_paths(&config), vec![outer_dir, inner_dir]);
+        assert_eq!(
+            command_paths_under(&config, &home_dir()),
+            vec![outer_dir, inner_dir]
+        );
         let _ = std::fs::remove_dir_all(home);
     }
 
     #[test]
-    fn command_home_paths_resolves_absolute_command() {
+    fn command_paths_under_resolves_absolute_command() {
         let home = command_home_fixture("abs");
         let cmd = home.join(".local/bin/agent");
 
@@ -2150,7 +2145,7 @@ mod tests {
     }
 
     #[test]
-    fn command_home_paths_ignores_system_binaries() {
+    fn command_paths_under_ignores_system_binaries() {
         // A command outside $HOME needs no extra mounts.
         let home = PathBuf::from("/home/definitely-not-this-user");
         assert!(
@@ -2162,7 +2157,7 @@ mod tests {
     }
 
     #[test]
-    fn command_home_paths_ignores_missing_and_relative_commands() {
+    fn command_paths_under_ignores_missing_and_relative_commands() {
         let home = command_home_fixture("miss");
         let path_env = home.join(".local/bin").display().to_string();
 
@@ -2330,7 +2325,7 @@ mod tests {
     }
 
     #[test]
-    fn command_home_paths_survives_symlink_loops() {
+    fn command_paths_under_survives_symlink_loops() {
         // The chain walk is capped; a loop must not hang or panic.
         let home = std::env::temp_dir()
             .join(format!("ai-jail-cmd-home-loop-{}", std::process::id()));

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -3,6 +3,24 @@ use crate::output;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Core runtime and toolchain locations granted read-only so the sandboxed
+/// command can exec and resolve its dynamic libraries. This is the macOS
+/// counterpart of the Linux base mounts in `bwrap.rs`, and it carries the
+/// same entries: `/opt` belongs here because Homebrew on Apple Silicon
+/// installs there, exactly as the Intel prefix `/usr/local` — already
+/// covered by `/usr` — does on the other architecture (issue #120).
+const SYSTEM_READ_PATHS: &[&str] = &[
+    "/System",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/etc",
+    "/private/etc",
+    "/Library",
+    "/opt",
+    "/dev",
+];
+
 pub struct SandboxGuard;
 
 pub fn check() -> Result<(), String> {
@@ -91,7 +109,12 @@ fn apply_child_env(cmd: &mut Command, config: &Config) {
 
     let host_env: Vec<(String, String)> = std::env::vars().collect();
     let env = if config.inherit_env_enabled() {
-        let mut env = Vec::new();
+        // The whole parent environment, secrets included — that is what
+        // the opt-in means. Starting from an empty vector here handed the
+        // child nothing at all (not even PATH), because `env_clear` above
+        // has already dropped what `Command` would otherwise inherit;
+        // bwrap reaches the same result by omitting `--clearenv`.
+        let mut env = host_env.clone();
         crate::config::apply_env_pass(&mut env, config.env_pass(), &host_env);
         env
     } else {
@@ -828,21 +851,14 @@ fn macos_read_paths(config: &Config, project_dir: &Path) -> Vec<PathBuf> {
         }
     }
 
-    // Core runtime and toolchain locations needed to execute binaries
-    // and resolve dynamic libraries on macOS.
-    for p in [
-        "/System",
-        "/usr",
-        "/bin",
-        "/sbin",
-        "/etc",
-        "/private/etc",
-        "/Library",
-        "/dev",
-    ] {
+    for p in SYSTEM_READ_PATHS {
         let pb = PathBuf::from(p);
         if super::path_exists(&pb) {
-            push_unique(pb);
+            // Canonicalize before deduplicating: `/etc` and `/private/etc`
+            // are the same directory on macOS and the rules are emitted
+            // canonically, so the raw forms would produce one duplicate
+            // allow in every profile.
+            push_unique(canonicalize_or_keep(&pb));
         }
     }
 
@@ -927,11 +943,14 @@ fn macos_read_paths(config: &Config, project_dir: &Path) -> Vec<PathBuf> {
                 push_unique(canonicalize_or_keep(p));
             }
         }
-        // The invoked command itself may live under $HOME (e.g. the
-        // official Claude installer targets ~/.local/bin); without a
-        // read allowance on its install paths the exec fails before
-        // the agent starts (#81).
-        for p in super::command_home_paths(config) {
+        // Without a read allowance on the command's install paths the
+        // exec fails before the agent starts (#81). Unlike Linux, where
+        // everything outside the private $HOME is already bind-mounted,
+        // a macOS profile denies by default everywhere, so the search
+        // covers the whole filesystem rather than just $HOME — an agent
+        // installed under /Applications or /nix/store needs the same
+        // grant that a ~/.local/bin one does (issue #120).
+        for p in super::command_paths_under(config, Path::new("/")) {
             push_unique(canonicalize_or_keep(&p));
         }
         if config.ssh_enabled() {
@@ -1412,6 +1431,66 @@ mod tests {
     }
 
     #[test]
+    fn system_reads_cover_both_homebrew_prefixes() {
+        // Regression for #120. The Intel prefix /usr/local is reachable
+        // through /usr, so only the Apple Silicon prefix can go missing —
+        // and it did, leaving Homebrew-installed agents unexecutable on
+        // exactly one architecture.
+        assert!(SYSTEM_READ_PATHS.contains(&"/opt"));
+        assert!(SYSTEM_READ_PATHS.contains(&"/usr"));
+    }
+
+    #[test]
+    fn reads_allow_command_installed_outside_home() {
+        // Regression for #120: the read grant for the invoked command
+        // used to stop at $HOME, so an agent installed anywhere else —
+        // a Homebrew prefix, /Applications, /nix/store — was denied and
+        // the exec failed before the agent started.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-seatbelt-cmd-out-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let home = root.join("home");
+        let prefix = root.join("prefix");
+        let libexec = prefix.join("libexec");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::create_dir_all(&libexec).unwrap();
+        let target = libexec.join("agent-1.0");
+        std::fs::write(&target, "#!/bin/sh\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            &target,
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&target, prefix.join("bin/agent")).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _path = EnvVarGuard::set("PATH", prefix.join("bin").as_os_str());
+
+        // The install prefix is deliberately outside $HOME; if the fixture
+        // ever landed inside it, the test would pass without proving
+        // anything.
+        assert!(!prefix.starts_with(&home));
+
+        let config = Config {
+            command: vec!["agent".into()],
+            private_home: Some(true),
+            ..Config::default()
+        };
+        let profile = generate_sbpl_profile(&config, &home.join("project"));
+
+        assert!(
+            profile.contains(&format!("(subpath \"{}\")", sbpl_path(&libexec)))
+        );
+        assert!(
+            profile.contains(&format!("(literal \"{}\")", sbpl_path(&target)))
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn restricted_reads_allow_root_node() {
         // Regression: without a read rule on the root node itself, the
         // dyld loader on macOS 26 aborts every dynamically-linked process
@@ -1595,13 +1674,23 @@ mod tests {
         let target = format!("{parent}/ai-jail-probe-{}", std::process::id());
         let _ = std::fs::remove_dir(format!("/private{target}"));
 
+        // One non-recursive mkdir, which is the call Claude Code makes.
+        // `mkdir -p` would instead walk down from `/tmp` and try to create
+        // it: the sandbox answers a denied write with EPERM rather than
+        // the EEXIST that mkdir tolerates, so the probe would fail on a
+        // path the agent never touches. Create the uid-scoped dir itself
+        // when it is absent — the exact reported operation — and fall
+        // back to a throwaway child so a live Claude Code session's
+        // directory is left alone.
+        let parent_exists = Path::new(&format!("/private{parent}")).is_dir();
+        let probe = if parent_exists { &target } else { &parent };
+
         let output = Command::new("/usr/bin/sandbox-exec")
             .arg("-p")
             .arg(&profile)
             .arg("--")
             .arg("/bin/mkdir")
-            .arg("-p")
-            .arg(&target)
+            .arg(probe)
             .output()
             .expect("failed to run sandbox-exec");
 
@@ -1688,8 +1777,11 @@ mod tests {
     #[test]
     fn writable_paths_grant_worktree_git_dir_and_common_dir() {
         let fixture = create_linked_worktree_fixture();
+        // Worktree metadata is opt-in; without --worktree discovery
+        // returns nothing and the assertions below have no subject.
         let config = Config {
             no_mise: Some(true),
+            no_worktree: Some(false),
             ..Config::default()
         };
         let paths = macos_writable_paths(&fixture.project_dir, &config, false);
@@ -1717,6 +1809,7 @@ mod tests {
         let fixture = create_linked_worktree_fixture();
         let config = Config {
             lockdown: Some(true),
+            no_worktree: Some(false),
             ..Config::default()
         };
         let paths = macos_read_paths(&config, &fixture.project_dir);


### PR DESCRIPTION
Fixes the macOS exec failure in #120, restores the CI coverage that would have caught it, and repairs everything that coverage immediately found.

## The reported bug

`macos_read_paths` is the seatbelt counterpart of the Linux base mounts in `bwrap.rs`, and it was missing `/opt`. Intel Homebrew installs under `/usr/local`, which is already reachable through the `/usr` grant, so the gap was invisible on that architecture — but on Apple Silicon every Homebrew-installed agent sits under `/opt/homebrew` and is denied, so `sandbox-exec` fails the exec before the agent starts.

The command-binary grant from #81 had a related limit. It searched only below `$HOME`, which is correct on Linux: everything outside the private `$HOME` is bind-mounted anyway. A seatbelt profile denies by default *everywhere*, so an agent under `/Applications` or `/nix/store` got no grant at all. macOS now searches from `/`, keeping the same narrow shape — the symlink chain plus the final target's directory, never the whole prefix.

`command_home_paths` was left as a single-caller alias for `command_paths_under`, so it is gone and each caller names its own root.

## Why CI did not catch it

**The macOS tests had no runner.** They ran on tag push until a09179b (v1.18.0) split the release matrix, leaving the macOS leg building without testing. `src/sandbox/seatbelt.rs` is `#[cfg(target_os = "macos")]`, so the Linux job only ever compiles those tests through the cross-target clippy step. Every seatbelt test written during and after that hardening pass was merged unrun.

**The nix job did not build the package.** `nix flake check` realizes `checks.*` only — it reports the package as "derivation evaluated to …ai-jail.drv" and stops. The job added to stop NixOS regressions was proving that nixfmt and treefmt pass and nothing more, while its comment claimed it built the crate and ran the suite. `nix build .#default` is what actually exercises the flake, and it is also what makes a `flake.nix` change reviewable without a local Nix.

## What the macOS job found on its first run

26 failures out of 526. Most were a poisoned `ENV_LOCK` cascading from a handful of real ones. Two were product bugs:

- **`ancestor_chain_has_symlink` walked past the project root.** `stop` is canonical and `start` is not, so textual equality never fires when a component above the root is a symlink; the walk then continued upward and rejected on that symlink — the one case the function's own doc comment calls irrelevant. Every in-project map with a not-yet-existing destination was refused. macOS hits it always (`/var` → `private/var`), but it is not macOS-specific: a Linux home reached through a symlink hits it too, and that is what the regression test builds, so it is covered on every run.
- **`--inherit-env` on macOS handed the child an empty environment**, not the host's — not even `PATH`. `apply_child_env` clears the environment and then rebuilt it from an empty vector. bwrap reaches the right result by omitting `--clearenv`.

The rest were bad tests: both worktree tests asserted on metadata they never opted into, and the `/tmp/claude-<uid>` probe used `mkdir -p`, which walks down from `/tmp` and tries to create it — a denied write answers EPERM, not the EEXIST `mkdir` tolerates — so it failed on a path the agent never touches.

Also deduplicates the system read list: `/etc` and `/private/etc` are one directory on macOS and rules are emitted canonically, so every profile carried a duplicate allow.

## Verification

- Linux: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, the same clippy against `aarch64-apple-darwin`, and 681 tests — all clean.
- macOS runner: 544 tests, 0 failures.
- nix: `flake check` plus a real `nix build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
