### PR TITLE
fix(bwrap): emit capability env after --clearenv, not before

### DIFF
--- a/src/sandbox/bwrap.rs
+++ b/src/sandbox/bwrap.rs
@@ -159,6 +159,7 @@ fn mounted_map_args<'a>(
     args
 }
 
+#[cfg_attr(test, derive(Default))]
 struct MountSet {
     base: Vec<Mount>,
     sys_masks: Vec<Mount>,
@@ -307,6 +308,19 @@ impl MountSet {
                     "DBUS_SESSION_BUS_ADDRESS".into(),
                 ]);
             }
+            // Environment hardening: by default the sandbox inherits
+            // only the safe allowlist (plus explicit env_pass
+            // entries); --inherit-env keeps the full host
+            // environment. Landlock-wrapper inner args are argv, not
+            // environment, and are unaffected.
+            args.extend(env_args(inherit_env, env_pass));
+            // Capability env must follow env_args, because that is what
+            // carries --clearenv and bwrap drops every --setenv preceding
+            // it. Emitted earlier, these were silently discarded while
+            // their sockets stayed bound, so --display bound the Wayland
+            // socket to a client that could not be told where it was, and
+            // --systemd-user did the same with the session bus (#122).
+            // This is also where ssh/claude/PS1 already sit, below.
             for (key, val) in &self.display_env {
                 args.push("--setenv".into());
                 args.push(key.clone());
@@ -317,12 +331,6 @@ impl MountSet {
                 args.push(key.clone());
                 args.push(val.clone());
             }
-            // Environment hardening: by default the sandbox inherits
-            // only the safe allowlist (plus explicit env_pass
-            // entries); --inherit-env keeps the full host
-            // environment. Landlock-wrapper inner args are argv, not
-            // environment, and are unaffected.
-            args.extend(env_args(inherit_env, env_pass));
         }
 
         // SSH agent env (non-lockdown only — lockdown clears env)
@@ -360,9 +368,13 @@ impl MountSet {
 /// bwrap would by default, with env_pass entries forced verbatim via
 /// `--setenv` (winning over the `--unsetenv` hardening above). The
 /// default filters to the safe allowlist: `--clearenv` followed by a
-/// `--setenv` per kept variable. `--setenv` values survive
-/// `--clearenv` regardless of argv order (bwrap applies them after
-/// clearing), so the later ssh/claude/PS1 setenvs are unaffected.
+/// `--setenv` per kept variable.
+///
+/// Argv order is load-bearing: bwrap applies these operations in
+/// sequence, so `--clearenv` discards every `--setenv` before it and
+/// keeps every `--setenv` after it. Anything that must reach the child
+/// has to be emitted after this function's output — which is why the
+/// display, systemd, ssh, claude and PS1 setenvs all follow it (#122).
 fn env_args(inherit_env: bool, env_pass: &[String]) -> Vec<String> {
     let host_env: Vec<(String, String)> = std::env::vars().collect();
     let mut args = Vec::new();
@@ -5386,6 +5398,91 @@ mod tests {
     }
 
     // ── Sandbox environment filtering ───────────────────────────
+
+    #[test]
+    fn capability_env_survives_clearenv() {
+        // Regression for #122. bwrap applies argv in sequence, so
+        // --clearenv discards every --setenv before it. display_env and
+        // systemd_env were emitted ahead of env_args (which is what carries
+        // --clearenv), so --display bound the Wayland socket while
+        // WAYLAND_DISPLAY never arrived and the client fell back to
+        // wayland-0, and --systemd-user lost DBUS_SESSION_BUS_ADDRESS the
+        // same way. XDG_RUNTIME_DIR hid the breakage by being rescued
+        // independently through the XDG_ allowlist prefix.
+        let set = MountSet {
+            display_env: vec![
+                ("XDG_RUNTIME_DIR".into(), "/run/user/1000".into()),
+                ("WAYLAND_DISPLAY".into(), "wayland-1".into()),
+                ("DISPLAY".into(), ":0".into()),
+                ("XAUTHORITY".into(), "/home/u/.Xauthority".into()),
+            ],
+            systemd_env: vec![(
+                "DBUS_SESSION_BUS_ADDRESS".into(),
+                "unix:path=/run/user/1000/bus".into(),
+            )],
+            ssh_env: vec![(
+                "SSH_AUTH_SOCK".into(),
+                "/run/user/1000/ssh".into(),
+            )],
+            claude_env: vec![("CLAUDE_CONFIG_DIR".into(), "/home/u/.c".into())],
+            ..MountSet::default()
+        };
+
+        let args = set.isolation_args(
+            Path::new("/home/u/project"),
+            false,
+            true,
+            false,
+            &[],
+        );
+        let clearenv = args
+            .iter()
+            .position(|a| a == "--clearenv")
+            .expect("non-inherit mode must clear the environment");
+
+        for name in [
+            "WAYLAND_DISPLAY",
+            "XDG_RUNTIME_DIR",
+            "DISPLAY",
+            "XAUTHORITY",
+            "DBUS_SESSION_BUS_ADDRESS",
+            "SSH_AUTH_SOCK",
+            "CLAUDE_CONFIG_DIR",
+            "PS1",
+        ] {
+            // Match the `--setenv NAME` pair, not the bare name: the
+            // hardening block above emits `--unsetenv SSH_AUTH_SOCK`
+            // first, and that earlier occurrence is not the one that
+            // has to survive.
+            let at = args
+                .iter()
+                .enumerate()
+                .position(|(i, a)| {
+                    a == name && i > 0 && args[i - 1] == "--setenv"
+                })
+                .unwrap_or_else(|| panic!("{name} must be set at all"));
+            assert!(
+                at > clearenv,
+                "{name} is emitted at {at}, before --clearenv at {clearenv}, \
+                 so bwrap discards it"
+            );
+        }
+
+        // The invariant rather than the enumeration: nothing this function
+        // emits may sit on the losing side of --clearenv, including groups
+        // added later.
+        let stranded: Vec<&String> = args[..clearenv]
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i > &0 && args[i - 1] == "--setenv")
+            .map(|(_, name)| name)
+            .collect();
+        assert!(
+            stranded.is_empty(),
+            "these --setenv values precede --clearenv and are discarded: \
+             {stranded:?}"
+        );
+    }
 
     #[test]
     fn env_args_filters_credentials_by_default() {


### PR DESCRIPTION
Fixes #122.

## Verified independently

The diagnosis holds. Confirmed in three ways rather than taken on the report's word:

**bubblewrap 0.11.2 on this machine:**

```
$ bwrap --ro-bind / / --setenv AIJAIL_PROBE before --clearenv --setenv PATH /usr/bin env | grep -c AIJAIL_PROBE
0
$ bwrap --ro-bind / / --clearenv --setenv PATH /usr/bin --setenv AIJAIL_PROBE after env | grep AIJAIL_PROBE
AIJAIL_PROBE=after
```

**Argv order in the real build:** `WAYLAND_DISPLAY` at token 283, `--clearenv` at 288.

**End to end, before the fix:**

```
WAYLAND_DISPLAY=[<LOST>] XDG_RUNTIME_DIR=[/run/user/1026]
```

And after:

```
WAYLAND_DISPLAY=[wayland-1] XDG_RUNTIME_DIR=[/run/user/1026]
```

The report's one inaccuracy is cosmetic: the method is `MountSet::isolation_args`, not `args`.

## Why this hid for five releases

`discover_display` pushes `XDG_RUNTIME_DIR` next to `WAYLAND_DISPLAY`, and `XDG_RUNTIME_DIR` is rescued independently by the `XDG_` prefix in the default allowlist. The variable people check to confirm the display is wired up was the one variable that survived by accident.

## The fix

Move the `display_env` and `systemd_env` loops after `env_args()`, where `ssh_env`, `claude_env` and `PS1` already sit. The doc comment on `env_args()` claimed the opposite of the bwrap behavior above and is corrected.

## No capability widens

- Both vectors are populated only under their existing opt-in (`--display` / `--x11` / `--systemd-user`), and both are empty under `--lockdown` — the loops live in the non-lockdown branch and stay there.
- The values are the ones discovery already computed and validated: `is_safe_xdg_runtime` pins `XDG_RUNTIME_DIR` to `/run/user/<uid>` with a mode check, `WAYLAND_DISPLAY` must be a single path component, the target must really be a socket, and the bind is `src == dest`.
- `XDG_RUNTIME_DIR` is the only name that both the allowlist and `display_env` set, and they set the identical host value, so the reordering cannot change it.

Checked by running it, not by reading it:

| invocation | result |
| --- | --- |
| `--display` | `WAYLAND_DISPLAY=wayland-1` |
| _no flags_ | `WAYLAND_DISPLAY`, `DISPLAY`, `DBUS_SESSION_BUS_ADDRESS` all unset |
| `--lockdown --display` | all unset, `PATH` still the lockdown one |
| `--display --x11` | `WAYLAND_DISPLAY` and `DISPLAY` both set |
| `--inherit-env` | unchanged |

## Precedence change worth flagging

`--env WAYLAND_DISPLAY=x` together with `--display` now loses to the discovered value, where before it won by default — because `display_env` was being discarded entirely. Discovered capability env is emitted last, which is what `ssh_env` and `claude_env` have always done, so this makes display consistent with them rather than introducing a new rule. The combination is pathological anyway: it asks ai-jail to bind the real socket and then misname it.

## Test

`capability_env_survives_clearenv` asserts every capability variable is emitted *after* `--clearenv`, and then asserts the general invariant that no `--setenv` at all precedes it, so a group added later in the wrong place fails too. It matches the `--setenv NAME` pair rather than the bare name — the hardening block emits `--unsetenv SSH_AUTH_SOCK` earlier, which caught a false positive in my first draft.

Confirmed it fails without the fix:

```
WAYLAND_DISPLAY is emitted at 21, before --clearenv at 32, so bwrap discards it
```

`MountSet` gains a test-only `Default` so the ordering can be asserted without a live Wayland session — `is_safe_xdg_runtime` requires a real `/run/user/<uid>`, so discovery cannot be driven on CI.

## Out of scope, noted

`--x11` without `--display` is a complete no-op: `enable_display = !lockdown && config.display_enabled()` gates `discover_display`, so neither the `/tmp/.X11-unix` bind nor `DISPLAY` happens. That predates this bug, and changing it would *widen* a capability, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
