### PR TITLE
fix(seatbelt): name the symlink nodes and ancestors a path walk needs

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -118,9 +118,27 @@ compromised agent use `TIOCSTI` to inject input into another of your shells.
 When ai-jail is not proxying a PTY, no terminal ioctl is granted at all.
 `/dev/ptmx` stays available so the sandbox can allocate its own PTYs; a PTY
 created inside the sandbox is not covered by the path-scoped rule. Linux
-denies `TIOCSTI` outright through seccomp. On both platforms,
-kernel and driver bugs, terminal emulator bugs (especially after terminal
-passthrough), and sandbox backend defects remain residual risk.
+denies `TIOCSTI` outright through seccomp.
+
+The macOS profile also grants `file-read-metadata` on each directory above an
+allowed path, and on the symlink nodes leading to the command. Seatbelt
+resolves a path one component at a time, so without this an allowed leaf stays
+unreachable through the path callers actually walk. The grant is `stat()` of
+those directory nodes only: it does not make them listable and does not reach
+anything inside them, so it exposes the existence, mode and mtime of
+directories the profile already grants access underneath — for a default run,
+the chain down to the project and to the agent's own install. It is deliberately
+narrower than a blanket `(allow file-read-metadata (subpath "/"))`, which would
+also override the profile's own deny-list and let `stat` answer for `~/.ssh`
+and `~/.aws`.
+
+Naming the command's PATH entry matters for containment, not only for startup:
+when that node is invisible, `execvp` does not fail, it continues down `PATH`
+and runs the first match inside an already-readable prefix such as the Homebrew
+one — a different build of the same tool than the one ai-jail resolved and
+granted access to. On both platforms, kernel and driver bugs, terminal emulator
+bugs (especially after terminal passthrough), and sandbox backend defects remain
+residual risk.
 
 ## Reporting vulnerabilities
 

--- a/src/sandbox/seatbelt.rs
+++ b/src/sandbox/seatbelt.rs
@@ -315,6 +315,99 @@ fn push_path_rule(profile: &mut String, verb: &str, action: &str, path: &Path) {
     profile.push_str(&format!("({verb} {action} ({pattern} \"{escaped}\"))\n"));
 }
 
+/// Grant read-metadata on every directory above an allowed path.
+///
+/// Seatbelt resolves a path one component at a time, so an allowed leaf stays
+/// unreachable unless each directory above it can be `stat`ed. The allow-list
+/// names leaves, never the chain to them, and nothing else supplies it. The
+/// clearest symptom is that no Node script can run inside the mounted project:
+///
+/// ```text
+/// $ node script.js
+/// Error: EPERM: operation not permitted, lstat '/Users'
+///     at Object.realpathSync (node:fs)
+/// ```
+///
+/// `node -e` works, because it never resolves an entry file. The same applies
+/// to any tool that calls `realpath(3)` on its own argv\[0\] or entry point.
+///
+/// `(literal ...)` on a directory grants `stat()` of that node alone — not
+/// listing it, and not reaching anything inside it. Verified against the
+/// shipped profile: `ls /Users`, `ls ~`, `stat ~/.ssh/config`,
+/// `stat ~/.aws/credentials` and `stat ~/.oci` all stay denied; the only new
+/// answer is the existence and mtime of directories the profile already
+/// grants access underneath.
+///
+/// Emitted before the deny-list so an explicit `--deny-path` on one of these
+/// directories still wins.
+fn push_ancestor_metadata_rules(profile: &mut String, read_paths: &[PathBuf]) {
+    let root = Path::new("/");
+    let mut seen: Vec<PathBuf> = Vec::new();
+    for path in read_paths {
+        let mut cur = path.parent();
+        while let Some(dir) = cur {
+            if dir == root {
+                break;
+            }
+            if !seen.contains(&dir.to_path_buf()) {
+                seen.push(dir.to_path_buf());
+            }
+            cur = dir.parent();
+        }
+    }
+    seen.sort();
+    for dir in seen {
+        let escaped = sbpl_escape(dir.to_string_lossy().as_ref());
+        profile.push_str(&format!(
+            "(allow file-read-metadata (literal \"{escaped}\"))\n"
+        ));
+    }
+}
+
+/// Grant read-metadata on a path that *is* a symlink, using the path as
+/// given rather than its resolved target.
+///
+/// `push_path_rule` canonicalizes, so a symlink only ever reaches the profile
+/// as the thing it points at. Seatbelt checks read-metadata on the symlink
+/// node itself while resolving a path, so the allowed target stays
+/// unreachable through the path callers actually walk. For a PATH entry that
+/// is fatal in a quiet way: `command_paths_under` picks
+/// `~/.local/bin/<tool>`, the profile only names its target, `execvp` cannot
+/// see the entry, and exec falls through to whatever build of the same tool
+/// sits further down PATH inside an already-readable prefix such as
+/// `/opt/homebrew/bin` -- so the sandbox runs a binary it never vetted.
+///
+/// Metadata on the node grants stat() of the link itself, never its contents.
+fn push_symlink_node_rule(profile: &mut String, path: &Path) {
+    let is_symlink = path
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if !is_symlink {
+        return;
+    }
+    // Resolve the ancestors but keep the final component as written: the
+    // kernel matches rules against the path it has already resolved, so a
+    // wholly raw literal misses whenever a directory above the link is
+    // itself a symlink (a PATH entry under /var, say), while a wholly
+    // canonical one collapses onto the target and misses the node.
+    let Some(node) = symlink_node_rule_path(path) else {
+        return;
+    };
+    let escaped = sbpl_escape(node.to_string_lossy().as_ref());
+    profile.push_str(&format!(
+        "(allow file-read-metadata (literal \"{escaped}\"))\n"
+    ));
+}
+
+/// The path a symlink node must be named by in the profile: its parent
+/// canonicalized, its own name left alone.
+fn symlink_node_rule_path(path: &Path) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    let name = path.file_name()?;
+    Some(canonicalize_or_keep(parent).join(name))
+}
+
 /// Sections that don't depend on filesystem policy. Always emitted first so
 /// the file structure is predictable across modes.
 fn push_static_sections(
@@ -434,6 +527,20 @@ fn push_file_read_section(
     // dyld needs the root node to resolve absolute paths. This literal rule
     // does not grant any filesystem subtree.
     profile.push_str("(allow file-read* (literal \"/\"))\n");
+    // On macOS /etc, /var and /tmp are symlinks into /private. Seatbelt runs a
+    // read-metadata check on every component while resolving a path, and the
+    // allow-list below only ever names resolved targets (push_path_rule
+    // canonicalizes), so without these literals each allowed subtree stays
+    // unreachable through the path programs actually use. That breaks
+    // getaddrinfo (no DNS) and the TLS trust store at /etc/ssl/cert.pem, and
+    // Node refuses to boot from a cwd that resolves through /private.
+    // `(literal ...)` grants stat() on those exact nodes only -- never their
+    // contents -- so it does not widen the read allow-list or the deny-list.
+    profile.push_str(
+        "(allow file-read-metadata (literal \"/private\") (literal \"/etc\") \
+         (literal \"/var\") (literal \"/tmp\") (literal \"/private/tmp\") \
+         (literal \"/private/var\"))\n",
+    );
     if is_claude {
         // /tmp is a symlink into /private/tmp; push_path_rule
         // canonicalizes every path it emits, so the write grant for
@@ -444,10 +551,30 @@ fn push_file_read_section(
         // does via the literal "/tmp/..." path (not "/private/tmp/...")
         // still gets EPERM even with the write rule below in place.
         profile.push_str("(allow file-read* (literal \"/tmp\"))\n");
+        // The write grant in push_file_write_section is not enough: Claude Code
+        // reads its session and tool-output state back from this directory, and
+        // Node's recursive mkdir stat()s the path to confirm it is a directory,
+        // so a write-only grant fails at startup with
+        //   EEXIST: file already exists, mkdir '/tmp/claude-<uid>'
+        // once the directory exists.
+        let uid = unsafe { nix::libc::getuid() };
+        profile.push_str(&format!(
+            "(allow file-read* (subpath \"/private/tmp/claude-{uid}\"))\n"
+        ));
     }
-    for rd_path in macos_read_paths(config, project_dir) {
-        push_path_rule(profile, "allow", "file-read*", &rd_path);
+    let read_paths = macos_read_paths(config, project_dir);
+    for rd_path in &read_paths {
+        push_path_rule(profile, "allow", "file-read*", rd_path);
     }
+    // macos_read_paths canonicalizes, which is what dedupes the rules but
+    // also loses every symlink node on the way to the command. Re-walk the
+    // raw paths so the PATH entry itself stays resolvable.
+    if !config.lockdown_enabled() {
+        for p in super::command_paths_under(config, Path::new("/")) {
+            push_symlink_node_rule(profile, &p);
+        }
+    }
+    push_ancestor_metadata_rules(profile, &read_paths);
     profile.push('\n');
     for deny_path in deny_paths {
         push_path_rule(profile, "deny", "file-read*", deny_path);
@@ -1490,6 +1617,228 @@ mod tests {
         );
         assert!(
             profile.contains(&format!("(literal \"{}\")", sbpl_path(&target)))
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn claude_tmp_dir_is_readable_not_only_writable() {
+        // #100 granted this path but only for writing, and its probe only
+        // ever issued a mkdir. Claude Code reads its session and
+        // tool-output state back, and Node's recursive mkdir stat()s the
+        // path to confirm it is a directory — that denied stat is what
+        // surfaces to the user as
+        //   EEXIST: file already exists, mkdir '/tmp/claude-<uid>'
+        // on the second launch, once the directory exists.
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+        let _lock = ENV_LOCK.lock().unwrap();
+        let profile = generate_sbpl_profile(
+            &Config {
+                command: vec!["claude".into()],
+                ..Config::default()
+            },
+            &PathBuf::from("/tmp/test-project"),
+        );
+
+        // Probe a throwaway child so a live Claude Code session's own
+        // directory is left alone.
+        let parent = format!("/tmp/claude-{}", unsafe { nix::libc::getuid() });
+        let probe =
+            format!("{parent}/ai-jail-read-probe-{}", std::process::id());
+        let real = format!("/private{probe}");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::write(format!("{real}/x"), "hi\n").unwrap();
+
+        let output = Command::new("/usr/bin/sandbox-exec")
+            .arg("-p")
+            .arg(&profile)
+            .arg("--")
+            .arg("/bin/cat")
+            .arg(format!("{probe}/x"))
+            .output()
+            .expect("sandbox-exec should run");
+
+        let _ = std::fs::remove_dir_all(&real);
+        assert!(
+            output.status.success(),
+            "reading back from {probe} was denied: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn reads_allow_the_command_path_entry_itself() {
+        // #121 grants "the symlink chain plus the final target's
+        // directory", but macos_read_paths canonicalizes every path it
+        // collects, so each chain element collapses onto its target and
+        // the PATH entry — the node execvp actually walks — is never
+        // named. The assertions above pass either way, which is why this
+        // stayed hidden.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-seatbelt-entry-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let home = root.join("home");
+        let bin = root.join("prefix/bin");
+        let libexec = root.join("prefix/libexec");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&libexec).unwrap();
+        let target = libexec.join("agent-1.0");
+        std::fs::write(&target, "#!/bin/sh\nexit 0\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            &target,
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        let entry = bin.join("agent");
+        std::os::unix::fs::symlink(&target, &entry).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _path = EnvVarGuard::set("PATH", bin.as_os_str());
+
+        let config = Config {
+            command: vec!["agent".into()],
+            private_home: Some(true),
+            ..Config::default()
+        };
+        let profile = generate_sbpl_profile(&config, &home.join("project"));
+
+        // The entry itself, not just what it points at.
+        let node = symlink_node_rule_path(&entry).unwrap();
+        assert!(
+            profile.contains(&format!(
+                "(allow file-read-metadata (literal \"{}\"))",
+                sbpl_escape(node.to_string_lossy().as_ref())
+            )),
+            "profile never names the PATH entry:\n{profile}"
+        );
+        // ... and it must not have been collapsed onto the target.
+        assert_ne!(node, canonicalize_or_keep(&entry));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn command_path_entry_is_reachable_under_generated_profile() {
+        // End-to-end counterpart: without the rule above, execvp cannot
+        // see the entry ai-jail resolved and vetted, and falls through to
+        // whatever build of the same tool sits further down PATH inside an
+        // already-readable prefix — /opt became one of those in #121. The
+        // sandbox then runs a binary it never inspected, with no warning.
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+        let _lock = ENV_LOCK.lock().unwrap();
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-seatbelt-exec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let home = root.join("home");
+        let bin = root.join("prefix/bin");
+        let libexec = root.join("prefix/libexec");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&libexec).unwrap();
+        let target = libexec.join("agent-1.0");
+        std::fs::write(&target, "#!/bin/sh\nexit 0\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            &target,
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        let entry = bin.join("agent");
+        std::os::unix::fs::symlink(&target, &entry).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _path = EnvVarGuard::set("PATH", bin.as_os_str());
+
+        let config = Config {
+            command: vec!["agent".into()],
+            private_home: Some(true),
+            ..Config::default()
+        };
+        let profile = generate_sbpl_profile(&config, &home.join("project"));
+
+        let output = Command::new("/usr/bin/sandbox-exec")
+            .arg("-p")
+            .arg(&profile)
+            .arg("--")
+            .arg("/bin/test")
+            .arg("-x")
+            .arg(&entry)
+            .output()
+            .expect("sandbox-exec should run");
+        assert!(
+            output.status.success(),
+            "PATH entry {} unreachable under the profile: {}",
+            entry.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn reads_allow_metadata_on_ancestors_but_not_their_contents() {
+        // Seatbelt resolves a path component by component, so an allowed
+        // leaf is unreachable unless every directory above it can be
+        // stat()ed. Nothing else supplies that: the allow-list names
+        // leaves, never the chain to them, which is why `node script.js`
+        // in the mounted project dies with EPERM lstat '/Users' while
+        // `node -e` is fine.
+        //
+        // The grant must stay metadata-only: stat() of the directory
+        // node, never a listing and never anything inside it.
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+        let _lock = ENV_LOCK.lock().unwrap();
+        let root = std::env::temp_dir()
+            .join(format!("ai-jail-seatbelt-anc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let project = root.join("nested/project");
+        std::fs::create_dir_all(&project).unwrap();
+        let sibling = root.join("nested/secret.txt");
+        std::fs::write(&sibling, "secret\n").unwrap();
+
+        let config = Config {
+            command: vec!["bash".into()],
+            ..Config::default()
+        };
+        let profile = generate_sbpl_profile(&config, &project);
+        let ancestor = canonicalize_or_keep(&root.join("nested"));
+
+        let run = |args: &[&std::ffi::OsStr]| {
+            Command::new("/usr/bin/sandbox-exec")
+                .arg("-p")
+                .arg(&profile)
+                .arg("--")
+                .args(args)
+                .output()
+                .expect("sandbox-exec should run")
+                .status
+                .success()
+        };
+
+        assert!(
+            run(&["/usr/bin/stat".as_ref(), ancestor.as_os_str()]),
+            "ancestor {} should be stat-able",
+            ancestor.display()
+        );
+        assert!(
+            !run(&["/bin/ls".as_ref(), ancestor.as_os_str()]),
+            "ancestor {} must not be listable",
+            ancestor.display()
+        );
+        assert!(
+            !run(&[
+                "/bin/cat".as_ref(),
+                canonicalize_or_keep(&sibling).as_os_str()
+            ]),
+            "a sibling of the project must stay unreadable"
         );
 
         let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
Fixes #124.

`push_path_rule` canonicalizes every path it emits, but seatbelt runs a read-metadata check on **each component** while resolving one. Anything an allowed target is reached *through* therefore never appears in the profile, and the grant does not apply to the path callers actually walk.

The file already works around one instance of this — the `(literal "/tmp")` rule under `is_claude`, whose comment describes exactly this mechanism — but the shape is general. This names the rest of the chain.

## Relationship to the previous macOS fixes

This sits directly on top of two merged PRs and closes the gaps they left:

- **#100** ([`98cb708`](https://github.com/akitaonrails/ai-jail/pull/100)) restored `file-ioctl` on the PTY and granted `/private/tmp/claude-<uid>`. That grant is write-only, and its probe only ever issued a `mkdir`. Claude Code *reads* that state back, so the directory it can create is one it cannot use. The read rule here completes it, and the new test exercises the read rather than the create.
- **#121** ([`5b4ceb9`](https://github.com/akitaonrails/ai-jail/pull/121)) added `/opt` to `SYSTEM_READ_PATHS` and made the command-binary search start from `/`, keeping "the symlink chain plus the final target's directory". The chain is collected correctly by `command_paths_under`, then canonicalized away at `macos_read_paths` before it reaches the profile — so only the target is ever named. This emits the chain the commit message already intended.

Worth flagging: those two changes interact. Before #121, an unreachable PATH entry meant `exec` simply failed. After it, `/opt` is readable, so `execvp` keeps walking and runs whatever match it finds there instead. The failure became silent.

## What breaks today

**No DNS and no TLS.** `/etc`, `/var` and `/tmp` are symlinks into `/private`, so their targets are allowed and unreachable at the same time.

```sh
sandbox-exec -f net.sb /bin/dd if=/private/etc/ssl/cert.pem bs=1 count=1 of=/dev/null
# 1 bytes transferred
sandbox-exec -f net.sb /bin/dd if=/etc/ssl/cert.pem bs=1 count=1 of=/dev/null
# dd: /etc/ssl/cert.pem: Operation not permitted
```

`curl https://api.anthropic.com/` answers `000` inside the profile — `Could not resolve host`, and by IP, `error setting certificate verify locations`. Transport is fine: `curl -k` to an IP answers `301`. With the metadata literals the same request answers `404`, having resolved, connected and verified the chain.

**The sandbox execs a binary it never vetted.** The profile grants the resolved target but not the PATH entry:

```
(allow file-read* (literal "…/.local/share/claude/versions/2.1.241"))
(allow file-read* (subpath "…/.local/share/claude/versions"))
```

`~/.local/bin/claude` — the node `execvp` walks — gets nothing, so it is skipped and the search continues:

```
~/.bun/bin/claude        invisible
~/.local/bin/claude      invisible     <- resolved and granted by ai-jail
/opt/homebrew/bin/claude executable    <- /opt is readable since #121
```

On this machine that meant the jail ran a stale Homebrew cask (2.1.228) while the host ran 2.1.241. `reads_allow_command_installed_outside_home` asserts the libexec directory and the target, never the entry, so it stayed green throughout.

**No Node script can run.** No directory above an allowed path is stat-able, so anything that `realpath(3)`s its own entry point dies before it starts — inside the mounted project included:

```
$ node script.js
Error: EPERM: operation not permitted, lstat '/Users'
    at Object.realpathSync (node:fs:3315:29)
    at resolveMainPath (node:internal/modules/run_main:35:21)
```

`node -e` works, because it never resolves an entry file, so this surfaces only once an agent runs a script, a test runner, or any npm/bun CLI with a `#!/usr/bin/env node` shebang.

**Claude Code cannot read its own scratch state.** Node's recursive `mkdir` gets `EEXIST` from the kernel, then `stat`s the path to confirm it is a directory; the denied `stat` is what reaches the user as `EEXIST: file already exists, mkdir '/tmp/claude-<uid>'` on the second launch.

## Containment

Every added rule is `file-read-metadata` on a directory or symlink node on the way to something already allowed, plus the one `file-read*` on the Claude scratch dir. Diffing a generated profile before and after: nothing is removed, and no `file-write*` is added.

Seventeen probes answer identically on both profiles — `~/.ssh/id_*`, `~/.aws/credentials`, `~/.oci/config`, `~/.kube/config`, `~/.config/gcloud`, `~/.terraform.d`, `~/.zsh_history`, `login.keychain-db`, `stat` on files under those directories, listing `$HOME`, `~/Documents` and `~/Library`, and writes to `~`, `~/Documents` and `/etc`. The only difference is the five broken capabilities.

I deliberately did **not** use `(allow file-read-metadata (subpath "/"))`. It is the obvious one-liner and it does fix DNS, but it overrides the profile's own deny-list — `stat ~/.ssh/config` and `stat ~/.aws/credentials` both start answering, with sizes and modes — and rule placement makes no difference, before or after the `(deny file-read* …)` block. The literals name only the chain that is actually walked.

`docs/SECURITY.md` is updated in the same spirit as #100: what the grant covers beyond its intended target, why it is narrower than the blanket form, and why naming the PATH entry is a containment property rather than only a startup one.

## Tests

Four added, in the behavioural style #100 introduced — they generate a profile and run `sandbox-exec` against it, rather than asserting on strings alone:

- `reads_allow_the_command_path_entry_itself` — the profile names the entry, and has not collapsed it onto the target
- `command_path_entry_is_reachable_under_generated_profile` — the entry is executable under the profile
- `reads_allow_metadata_on_ancestors_but_not_their_contents` — an ancestor is `stat`-able, and is still neither listable nor readable, and a sibling of the project stays unreadable
- `claude_tmp_dir_is_readable_not_only_writable` — reads back a throwaway child of the scratch dir, leaving a live session's own directory alone

Each fails with its corresponding rule removed and passes with it. Full suite green — 549 passed, 0 failed — run repeatedly to check for ordering flakes; the two tests that call `generate_sbpl_profile` take `ENV_LOCK`, without which they race the tests that mutate `HOME`.

Tested on macOS 26.6.2, arm64, against Claude Code 2.1.241.
