### PR TITLE
fix: build on alpine linux

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1092,12 +1092,10 @@ fn run_with_passthrough(
             if nix::libc::setsid() == -1 {
                 return Err(std::io::Error::last_os_error());
             }
-            if nix::libc::ioctl(
-                slave_raw,
-                nix::libc::TIOCSCTTY as nix::libc::c_ulong,
-                0,
-            ) == -1
-            {
+            // `ioctl`'s request argument is `c_ulong` on glibc and
+            // macOS but `c_int` on musl; `as _` lets the cast follow
+            // whichever the target libc declares.
+            if nix::libc::ioctl(slave_raw, nix::libc::TIOCSCTTY as _, 0) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
             nix::libc::dup2(slave_raw, 0);

--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -321,11 +321,13 @@ fn compile_filter(
     }
     rules.insert(libc::SYS_socket, socket_rules);
 
+    // `TIOCSTI` is a `c_ulong` const on glibc but `c_int` on musl;
+    // `as _` coerces either to the `u64` the condition expects.
     let tiocsti = SeccompCondition::new(
         1,
         SeccompCmpArgLen::Qword,
         SeccompCmpOp::Eq,
-        libc::TIOCSTI,
+        libc::TIOCSTI as _,
     )
     .and_then(|condition| SeccompRule::new(vec![condition]))
     .map_err(|e| format!("Seccomp: failed to build ioctl rules: {e}"))?;

--- a/tests/resize_integration.rs
+++ b/tests/resize_integration.rs
@@ -156,11 +156,7 @@ fn resize_pty_delivers_sigwinch_and_new_size() {
     unsafe {
         cmd.pre_exec(move || {
             nix::libc::setsid();
-            nix::libc::ioctl(
-                slave_fd,
-                nix::libc::TIOCSCTTY as nix::libc::c_ulong,
-                0,
-            );
+            nix::libc::ioctl(slave_fd, nix::libc::TIOCSCTTY as _, 0);
             Ok(())
         });
     }
@@ -221,11 +217,7 @@ fn resize_sequence_scroll_region_before_pty_resize() {
     unsafe {
         cmd.pre_exec(move || {
             nix::libc::setsid();
-            nix::libc::ioctl(
-                slave_fd,
-                nix::libc::TIOCSCTTY as nix::libc::c_ulong,
-                0,
-            );
+            nix::libc::ioctl(slave_fd, nix::libc::TIOCSCTTY as _, 0);
             Ok(())
         });
     }
@@ -310,11 +302,7 @@ fn resize_grow_and_shrink() {
     unsafe {
         cmd.pre_exec(move || {
             nix::libc::setsid();
-            nix::libc::ioctl(
-                slave_fd,
-                nix::libc::TIOCSCTTY as nix::libc::c_ulong,
-                0,
-            );
+            nix::libc::ioctl(slave_fd, nix::libc::TIOCSCTTY as _, 0);
             Ok(())
         });
     }


### PR DESCRIPTION
The ioctl request constants TIOCSCTTY and TIOCSTI have different integer types on glibc (c_ulong) and musl (c_int), so the hard-coded casts broke the build on Alpine. Replacing them with `as _` lets the compiler pick whatever type each platform's libc expects.